### PR TITLE
Allocators

### DIFF
--- a/Pathtracer.vcxproj
+++ b/Pathtracer.vcxproj
@@ -282,6 +282,7 @@
     <ClInclude Include="Src\Core\Assertion.h" />
     <ClInclude Include="Src\Core\BitArray.h" />
     <ClInclude Include="Src\Core\Compare.h" />
+    <ClInclude Include="Src\Core\Constructors.h" />
     <ClInclude Include="Src\Core\Format.h" />
     <ClInclude Include="Src\Core\Hash.h" />
     <ClInclude Include="Src\Core\HashMap.h" />

--- a/Pathtracer.vcxproj
+++ b/Pathtracer.vcxproj
@@ -274,6 +274,9 @@
     <ClInclude Include="Src\BVH\Converters\BVH8Converter.h" />
     <ClInclude Include="Src\BVH\Converters\BVH4Converter.h" />
     <ClInclude Include="Src\Config.h" />
+    <ClInclude Include="Src\Core\Allocators\Allocator.h" />
+    <ClInclude Include="Src\Core\Allocators\LinearAllocator.h" />
+    <ClInclude Include="Src\Core\Allocators\PinnedAllocator.h" />
     <ClInclude Include="Src\Core\Array.h" />
     <ClInclude Include="Src\Core\Assertion.h" />
     <ClInclude Include="Src\Core\BitArray.h" />

--- a/Pathtracer.vcxproj
+++ b/Pathtracer.vcxproj
@@ -277,6 +277,7 @@
     <ClInclude Include="Src\Core\Allocators\Allocator.h" />
     <ClInclude Include="Src\Core\Allocators\LinearAllocator.h" />
     <ClInclude Include="Src\Core\Allocators\PinnedAllocator.h" />
+    <ClInclude Include="Src\Core\Allocators\StackAllocator.h" />
     <ClInclude Include="Src\Core\Array.h" />
     <ClInclude Include="Src\Core\Assertion.h" />
     <ClInclude Include="Src\Core\BitArray.h" />

--- a/Pathtracer.vcxproj.filters
+++ b/Pathtracer.vcxproj.filters
@@ -436,5 +436,8 @@
     <ClInclude Include="Src\Core\Allocators\StackAllocator.h">
       <Filter>Core\Allocators</Filter>
     </ClInclude>
+    <ClInclude Include="Src\Core\Constructors.h">
+      <Filter>Core</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Pathtracer.vcxproj.filters
+++ b/Pathtracer.vcxproj.filters
@@ -433,5 +433,8 @@
     <ClInclude Include="Src\Core\Allocators\LinearAllocator.h">
       <Filter>Core\Allocators</Filter>
     </ClInclude>
+    <ClInclude Include="Src\Core\Allocators\StackAllocator.h">
+      <Filter>Core\Allocators</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Pathtracer.vcxproj.filters
+++ b/Pathtracer.vcxproj.filters
@@ -199,6 +199,9 @@
     <Filter Include="Renderer\Integrators">
       <UniqueIdentifier>{19bb3711-1af8-4298-89b6-e719d008a79f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Core\Allocators">
+      <UniqueIdentifier>{4b1e0e24-b96c-4dac-884c-8f76c2f50eaf}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Src\Assets\OBJLoader.h">
@@ -420,6 +423,15 @@
     </ClInclude>
     <ClInclude Include="Src\Renderer\Integrators\AO.h">
       <Filter>Renderer\Integrators</Filter>
+    </ClInclude>
+    <ClInclude Include="Src\Core\Allocators\Allocator.h">
+      <Filter>Core\Allocators</Filter>
+    </ClInclude>
+    <ClInclude Include="Src\Core\Allocators\PinnedAllocator.h">
+      <Filter>Core\Allocators</Filter>
+    </ClInclude>
+    <ClInclude Include="Src\Core\Allocators\LinearAllocator.h">
+      <Filter>Core\Allocators</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Src/Args.cpp
+++ b/Src/Args.cpp
@@ -33,84 +33,85 @@ static bool parse_arg_bool(StringView str) {
 	}
 };
 
-static void parse_args(const Array<StringView> & args) {
-	struct Option {
-		StringView name_short;
-		StringView name_full;
+struct Option {
+	StringView name_short;
+	StringView name_full;
 
-		StringView help_text;
+	StringView help_text;
 
-		uint32_t num_args;
+	int num_args;
 
-		void (* action)(const Array<StringView> & args, size_t i);
-	};
+	void (* action)(const Array<StringView> & args, size_t i);
+};
+static Array<Option> options;
 
-	static Array<Option> options = {
-		Option { "I"_sv, "integrator"_sv, "Choose the interagor type. Supported options: pathtracer, ao"_sv, 1, [](const Array<StringView> & args, size_t i) {
-			if (args[i + 1] == "pathtracer") {
-				cpu_config.integrator = IntegratorType::PATHTRACER;
-			} else if (args[i + 1] == "ao") {
-				cpu_config.integrator = IntegratorType::AO;
-			} else {
-				IO::print("'{}' is not a recognized integrator type! Supported options: pathtracer, ao\n"_sv, args[i + 1]);
-				IO::exit(1);
-			}
-		} },
+static void parse_args(const Array<StringView> & args, Allocator * allocator) {
+	options = Array<Option>(allocator);
 
-		Option { "W"_sv, "width"_sv,   "Sets the width of the window"_sv,                     1, [](const Array<StringView> & args, size_t i) { cpu_config.initial_width       = parse_arg_int(args[i + 1]); } },
-		Option { "H"_sv, "height"_sv,  "Sets the height of the window"_sv,                    1, [](const Array<StringView> & args, size_t i) { cpu_config.initial_height      = parse_arg_int(args[i + 1]); } },
-		Option { "b"_sv, "bounce"_sv,  "Sets the number of pathtracing bounces"_sv,           1, [](const Array<StringView> & args, size_t i) { gpu_config.num_bounces         = Math::clamp(parse_arg_int(args[i + 1]), 0, MAX_BOUNCES - 1); } },
-		Option { "N"_sv, "samples"_sv, "Sets a target number of samples to use"_sv,           1, [](const Array<StringView> & args, size_t i) { cpu_config.output_sample_index = parse_arg_int(args[i + 1]); } },
-		Option { "o"_sv, "output"_sv,  "Sets path to output file. Supported formats: ppm"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.output_filename     = args[i + 1].start; } },
+	options.emplace_back("I"_sv, "integrator"_sv, "Choose the interagor type. Supported options: pathtracer, ao"_sv, 1, [](const Array<StringView> & args, size_t i) {
+		if (args[i + 1] == "pathtracer") {
+			cpu_config.integrator = IntegratorType::PATHTRACER;
+		} else if (args[i + 1] == "ao") {
+			cpu_config.integrator = IntegratorType::AO;
+		} else {
+			IO::print("'{}' is not a recognized integrator type! Supported options: pathtracer, ao\n"_sv, args[i + 1]);
+			IO::exit(1);
+		}
+	});
 
-		Option { "s"_sv, "scene"_sv, "Sets path to scene file. Supported formats: Mitsuba XML, OBJ, and PLY"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.scene_filenames.push_back(args[i + 1]); } },
-		Option { "S"_sv, "sky"_sv,   "Sets path to sky file. Supported formats: HDR"_sv,                         1, [](const Array<StringView> & args, size_t i) { cpu_config.sky_filename = args[i + 1]; } },
+	options.emplace_back("W"_sv, "width"_sv,   "Sets the width of the window"_sv,                     1, [](const Array<StringView> & args, size_t i) { cpu_config.initial_width       = parse_arg_int(args[i + 1]); });
+	options.emplace_back("H"_sv, "height"_sv,  "Sets the height of the window"_sv,                    1, [](const Array<StringView> & args, size_t i) { cpu_config.initial_height      = parse_arg_int(args[i + 1]); });
+	options.emplace_back("b"_sv, "bounce"_sv,  "Sets the number of pathtracing bounces"_sv,           1, [](const Array<StringView> & args, size_t i) { gpu_config.num_bounces         = Math::clamp(parse_arg_int(args[i + 1]), 0, MAX_BOUNCES - 1); });
+	options.emplace_back("N"_sv, "samples"_sv, "Sets a target number of samples to use"_sv,           1, [](const Array<StringView> & args, size_t i) { cpu_config.output_sample_index = parse_arg_int(args[i + 1]); });
+	options.emplace_back("o"_sv, "output"_sv,  "Sets path to output file. Supported formats: ppm"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.output_filename     = args[i + 1].start; });
 
-		Option { "b"_sv, "bvh"_sv, "Sets type of BLAS BVH used. Supported options: sah, sbvh, bvh4, bvh8"_sv, 1, [](const Array<StringView> & args, size_t i) {
-			if (args[i + 1] == "sah") {
-				cpu_config.bvh_type = BVHType::BVH;
-			} else if (args[i + 1] == "sbvh") {
-				cpu_config.bvh_type = BVHType::SBVH;
-			} else if (args[i + 1] == "bvh4") {
-				cpu_config.bvh_type = BVHType::BVH4;
-			} else if (args[i + 1] == "bvh8") {
-				cpu_config.bvh_type = BVHType::BVH8;
-			} else {
-				IO::print("'{}' is not a recognized BVH type! Supported options: sah, sbvh, bvh4, bvh8\n"_sv, args[i + 1]);
-				IO::exit(1);
-			}
-		} },
+	options.emplace_back("s"_sv, "scene"_sv, "Sets path to scene file. Supported formats: Mitsuba XML, OBJ, and PLY"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.scene_filenames.push_back(args[i + 1]); });
+	options.emplace_back("S"_sv, "sky"_sv,   "Sets path to sky file. Supported formats: HDR"_sv,                         1, [](const Array<StringView> & args, size_t i) { cpu_config.sky_filename = args[i + 1]; });
 
-		Option { { }, "nee"_sv, "Enables or disables Next Event Estimation"_sv,        1, [](const Array<StringView> & args, size_t i) { gpu_config.enable_next_event_estimation        = parse_arg_bool(args[i + 1]); } },
-		Option { { }, "mis"_sv, "Enables or disables Multiple Importance Sampling"_sv, 1, [](const Array<StringView> & args, size_t i) { gpu_config.enable_multiple_importance_sampling = parse_arg_bool(args[i + 1]); } },
+	options.emplace_back("b"_sv, "bvh"_sv, "Sets type of BLAS BVH used. Supported options: sah, sbvh, bvh4, bvh8"_sv, 1, [](const Array<StringView> & args, size_t i) {
+		if (args[i + 1] == "sah") {
+			cpu_config.bvh_type = BVHType::BVH;
+		} else if (args[i + 1] == "sbvh") {
+			cpu_config.bvh_type = BVHType::SBVH;
+		} else if (args[i + 1] == "bvh4") {
+			cpu_config.bvh_type = BVHType::BVH4;
+		} else if (args[i + 1] == "bvh8") {
+			cpu_config.bvh_type = BVHType::BVH8;
+		} else {
+			IO::print("'{}' is not a recognized BVH type! Supported options: sah, sbvh, bvh4, bvh8\n"_sv, args[i + 1]);
+			IO::exit(1);
+		}
+	});
 
-		Option { { }, "force-rebuild"_sv, "BVH will not be loaded from disk but rebuild from scratch"_sv, 0, [](const Array<StringView> & args, size_t i) { cpu_config.bvh_force_rebuild = true; } },
+	options.emplace_back(StringView { }, "nee"_sv, "Enables or disables Next Event Estimation"_sv,        1, [](const Array<StringView> & args, size_t i) { gpu_config.enable_next_event_estimation        = parse_arg_bool(args[i + 1]); });
+	options.emplace_back(StringView { }, "mis"_sv, "Enables or disables Multiple Importance Sampling"_sv, 1, [](const Array<StringView> & args, size_t i) { gpu_config.enable_multiple_importance_sampling = parse_arg_bool(args[i + 1]); });
 
-		Option { "O"_sv,  "optimize"_sv,    "Enables or disables BVH optimzation post-processing step"_sv,               1, [](const Array<StringView> & args, size_t i) { cpu_config.enable_bvh_optimization       = parse_arg_bool(args[i + 1]); } },
-		Option { "Ot"_sv, "opt-time"_sv,    "Sets time limit (in seconds) for BVH optimization"_sv,                      1, [](const Array<StringView> & args, size_t i) { cpu_config.bvh_optimizer_max_time        = parse_arg_int (args[i + 1]); } },
-		Option { "Ob"_sv, "opt-batches"_sv, "Sets a limit on the maximum number of batches used in BVH optimization"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.bvh_optimizer_max_num_batches = parse_arg_int (args[i + 1]); } },
+	options.emplace_back(StringView { }, "force-rebuild"_sv, "BVH will not be loaded from disk but rebuild from scratch"_sv, 0, [](const Array<StringView> & args, size_t i) { cpu_config.bvh_force_rebuild = true; });
 
-		Option { { }, "sah-node"_sv,   "Sets the SAH cost of an internal BVH node"_sv,                                                             1, [](const Array<StringView> & args, size_t i) { cpu_config.sah_cost_node = parse_arg_float(args[i + 1]); } },
-		Option { { }, "sah-leaf"_sv,   "Sets the SAH cost of a leaf BVH node"_sv,                                                                  1, [](const Array<StringView> & args, size_t i) { cpu_config.sah_cost_leaf = parse_arg_float(args[i + 1]); } },
-		Option { { }, "sbvh-alpha"_sv, "Sets the SBVH alpha constant. An alpha of 1 results in a regular BVH, alpha of 0 results in full SBVH"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.sbvh_alpha    = parse_arg_float(args[i + 1]); } },
+	options.emplace_back("O"_sv,  "optimize"_sv,    "Enables or disables BVH optimzation post-processing step"_sv,               1, [](const Array<StringView> & args, size_t i) { cpu_config.enable_bvh_optimization       = parse_arg_bool(args[i + 1]); });
+	options.emplace_back("Ot"_sv, "opt-time"_sv,    "Sets time limit (in seconds) for BVH optimization"_sv,                      1, [](const Array<StringView> & args, size_t i) { cpu_config.bvh_optimizer_max_time        = parse_arg_int (args[i + 1]); });
+	options.emplace_back("Ob"_sv, "opt-batches"_sv, "Sets a limit on the maximum number of batches used in BVH optimization"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.bvh_optimizer_max_num_batches = parse_arg_int (args[i + 1]); });
 
-		Option { { }, "mipmap"_sv,     "Enables or disables texture mipmapping"_sv,                                                     1, [](const Array<StringView> & args, size_t i) { gpu_config.enable_mipmapping = parse_arg_bool(args[i + 1]); } },
-		Option { { }, "mip-filter"_sv, "Sets the downsampling filter for creating mipmaps: Supported options: box, lanczos, kaiser"_sv, 1, [](const Array<StringView> & args, size_t i) {
-			if (args[i + 1] == "box") {
-				cpu_config.mipmap_filter = MipmapFilterType::BOX;
-			} else if (args[i + 1] == "lanczos") {
-				cpu_config.mipmap_filter = MipmapFilterType::LANCZOS;
-			} else if (args[i + 1] == "kaiser") {
-				cpu_config.mipmap_filter = MipmapFilterType::KAISER;
-			} else {
-				IO::print("'{}' is not a recognized Mipmap Filter!\n"_sv, args[i + 1]);
-				IO::exit(1);
-			}
-		} },
-		Option { "c"_sv, "compress"_sv, "Enables or disables texture block compression"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.enable_block_compression = parse_arg_bool(args[i + 1]); } },
-	};
+	options.emplace_back(StringView { }, "sah-node"_sv,   "Sets the SAH cost of an internal BVH node"_sv,                                                             1, [](const Array<StringView> & args, size_t i) { cpu_config.sah_cost_node = parse_arg_float(args[i + 1]); });
+	options.emplace_back(StringView { }, "sah-leaf"_sv,   "Sets the SAH cost of a leaf BVH node"_sv,                                                                  1, [](const Array<StringView> & args, size_t i) { cpu_config.sah_cost_leaf = parse_arg_float(args[i + 1]); });
+	options.emplace_back(StringView { }, "sbvh-alpha"_sv, "Sets the SBVH alpha constant. An alpha of 1 results in a regular BVH, alpha of 0 results in full SBVH"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.sbvh_alpha    = parse_arg_float(args[i + 1]); });
 
-	options.emplace_back("h"_sv, "help"_sv, "Displays this message"_sv, 0u, [](const Array<StringView> & args, size_t i) {
+	options.emplace_back(StringView { }, "mipmap"_sv,     "Enables or disables texture mipmapping"_sv,                                                     1, [](const Array<StringView> & args, size_t i) { gpu_config.enable_mipmapping = parse_arg_bool(args[i + 1]); });
+	options.emplace_back(StringView { }, "mip-filter"_sv, "Sets the downsampling filter for creating mipmaps: Supported options: box, lanczos, kaiser"_sv, 1, [](const Array<StringView> & args, size_t i) {
+		if (args[i + 1] == "box") {
+			cpu_config.mipmap_filter = MipmapFilterType::BOX;
+		} else if (args[i + 1] == "lanczos") {
+			cpu_config.mipmap_filter = MipmapFilterType::LANCZOS;
+		} else if (args[i + 1] == "kaiser") {
+			cpu_config.mipmap_filter = MipmapFilterType::KAISER;
+		} else {
+			IO::print("'{}' is not a recognized Mipmap Filter!\n"_sv, args[i + 1]);
+			IO::exit(1);
+		}
+	});
+	options.emplace_back("c"_sv, "compress"_sv, "Enables or disables texture block compression"_sv, 1, [](const Array<StringView> & args, size_t i) { cpu_config.enable_block_compression = parse_arg_bool(args[i + 1]); });
+
+	options.emplace_back("h"_sv, "help"_sv, "Displays this message"_sv, 0, [](const Array<StringView> & args, size_t i) {
 		for (int o = 0; o < options.size(); o++) {
 			const Option & option = options[o];
 
@@ -125,7 +126,7 @@ static void parse_args(const Array<StringView> & args) {
 
 	for (size_t i = 1; i < args.size(); i++) {
 		StringView arg = args[i];
-		String arg_name = Format().format("Arg {} ({})"_sv, i, arg);
+		String arg_name = Format(allocator).format("Arg {} ({})"_sv, i, arg);
 
 		Parser parser(arg, arg_name.view());
 
@@ -166,10 +167,10 @@ static void parse_args(const Array<StringView> & args) {
 	}
 }
 
-void Args::parse(int num_args, char ** args) {
-	Array<StringView> arguments(num_args);
+void Args::parse(int num_args, char ** args, Allocator * allocator) {
+	Array<StringView> arguments(num_args, allocator);
 	for (int i = 0; i < num_args; i++) {
 		arguments[i] = StringView::from_c_str(args[i]);
 	}
-	parse_args(arguments);
+	parse_args(arguments, allocator);
 }

--- a/Src/Args.cpp
+++ b/Src/Args.cpp
@@ -165,6 +165,8 @@ static void parse_args(const Array<StringView> & args, Allocator * allocator) {
 			cpu_config.scene_filenames.push_back(arg);
 		}
 	}
+
+	options = { }; // Free
 }
 
 void Args::parse(int num_args, char ** args, Allocator * allocator) {

--- a/Src/Args.h
+++ b/Src/Args.h
@@ -1,5 +1,6 @@
 #pragma once
+#include "Core/Allocators/Allocator.h"
 
 namespace Args {
-	void parse(int num_args, char ** args);
+	void parse(int num_args, char ** args, Allocator * allocator);
 }

--- a/Src/Assets/AssetManager.h
+++ b/Src/Assets/AssetManager.h
@@ -38,7 +38,7 @@ private:
 public:
 	template<typename FallbackLoader>
 	MeshDataHandle add_mesh_data(const String & filename, Allocator * allocator, FallbackLoader fallback_loader) {
-		String bvh_filename = BVHLoader::get_bvh_filename(filename.view());
+		String bvh_filename = BVHLoader::get_bvh_filename(filename.view(), allocator);
 		MeshDataHandle mesh_data_handle = add_mesh_data(filename, bvh_filename, allocator, fallback_loader);
 
 		return mesh_data_handle;

--- a/Src/Assets/AssetManager.h
+++ b/Src/Assets/AssetManager.h
@@ -37,15 +37,15 @@ private:
 
 public:
 	template<typename FallbackLoader>
-	MeshDataHandle add_mesh_data(const String & filename, FallbackLoader fallback_loader) {
+	MeshDataHandle add_mesh_data(const String & filename, Allocator * allocator, FallbackLoader fallback_loader) {
 		String bvh_filename = BVHLoader::get_bvh_filename(filename.view());
-		MeshDataHandle mesh_data_handle = add_mesh_data(filename, bvh_filename, fallback_loader);
+		MeshDataHandle mesh_data_handle = add_mesh_data(filename, bvh_filename, allocator, fallback_loader);
 
 		return mesh_data_handle;
 	}
 
 	template<typename FallbackLoader>
-	MeshDataHandle add_mesh_data(const String & filename, const String & bvh_filename, FallbackLoader fallback_loader) {
+	MeshDataHandle add_mesh_data(const String & filename, const String & bvh_filename, Allocator * allocator, FallbackLoader fallback_loader) {
 		MeshDataHandle & mesh_data_handle = mesh_data_cache[filename];
 
 		if (mesh_data_handle.handle != INVALID) return mesh_data_handle;
@@ -55,7 +55,7 @@ public:
 
 		bool bvh_loaded = BVHLoader::try_to_load(filename, bvh_filename, mesh_data, bvh);
 		if (!bvh_loaded) {
-			mesh_data.triangles = fallback_loader(filename);
+			mesh_data.triangles = fallback_loader(filename, allocator);
 
 			if (mesh_data.triangles.size() == 0) {
 				return { INVALID };

--- a/Src/Assets/BVHLoader.cpp
+++ b/Src/Assets/BVHLoader.cpp
@@ -5,6 +5,7 @@
 
 #include "Core/IO.h"
 #include "Core/Parser.h"
+#include "Core/Allocators/StackAllocator.h"
 
 #include "Util/Util.h"
 #include "Util/StringUtil.h"
@@ -33,7 +34,8 @@ bool BVHLoader::try_to_load(const String & filename, const String & bvh_filename
 		return false;
 	}
 
-	String file = IO::file_read(bvh_filename);
+	StackAllocator<> allocator;
+	String file = IO::file_read(bvh_filename, &allocator);
 	Parser parser(file.view(), bvh_filename.view());
 
 	BVHFileHeader header = parser.parse_binary<BVHFileHeader>();

--- a/Src/Assets/BVHLoader.cpp
+++ b/Src/Assets/BVHLoader.cpp
@@ -34,7 +34,7 @@ bool BVHLoader::try_to_load(const String & filename, const String & bvh_filename
 		return false;
 	}
 
-	StackAllocator<> allocator;
+	StackAllocator<KILOBYTES(8)> allocator;
 	String file = IO::file_read(bvh_filename, &allocator);
 	Parser parser(file.view(), bvh_filename.view());
 

--- a/Src/Assets/BVHLoader.cpp
+++ b/Src/Assets/BVHLoader.cpp
@@ -10,8 +10,8 @@
 #include "Util/Util.h"
 #include "Util/StringUtil.h"
 
-String BVHLoader::get_bvh_filename(StringView filename) {
-	return Util::combine_stringviews(filename, StringView::from_c_str(BVH_FILE_EXTENSION));
+String BVHLoader::get_bvh_filename(StringView filename, Allocator * allocator) {
+	return Util::combine_stringviews(filename, StringView::from_c_str(BVH_FILE_EXTENSION), allocator);
 }
 
 struct BVHFileHeader {

--- a/Src/Assets/BVHLoader.h
+++ b/Src/Assets/BVHLoader.h
@@ -13,7 +13,7 @@ namespace BVHLoader {
 	inline constexpr const char * BVH_FILE_EXTENSION = ".bvh";
 	inline constexpr int          BVH_FILETYPE_VERSION = 5;
 
-	String get_bvh_filename(StringView filename);
+	String get_bvh_filename(StringView filename, Allocator * allocator);
 
 	bool try_to_load(const String & filename, const String & bvh_filename, MeshData & mesh_data, BVH2 & bvh);
 	bool save(const String & bvh_filename, const MeshData & mesh_data, const BVH2 & bvh);

--- a/Src/Assets/Mitsuba/MitshairLoader.cpp
+++ b/Src/Assets/Mitsuba/MitshairLoader.cpp
@@ -6,13 +6,13 @@
 
 #include "Renderer/Triangle.h"
 
-Array<Triangle> MitshairLoader::load(const String & filename, SourceLocation location_in_mitsuba_file, float radius) {
-	String file = IO::file_read(filename);
+Array<Triangle> MitshairLoader::load(const String & filename, Allocator * allocator, SourceLocation location_in_mitsuba_file, float radius) {
+	String file = IO::file_read(filename, allocator);
 
 	Parser parser(file.view(), filename.view());
 
-	Array<Vector3> hair_vertices;
-	Array<int>     hair_strand_lengths;
+	Array<Vector3> hair_vertices      (allocator);
+	Array<int>     hair_strand_lengths(allocator);
 
 	size_t triangle_count = 0;
 	int strand_size = 0;

--- a/Src/Assets/Mitsuba/MitshairLoader.h
+++ b/Src/Assets/Mitsuba/MitshairLoader.h
@@ -5,5 +5,5 @@
 struct Triangle;
 
 namespace MitshairLoader {
-	Array<Triangle> load(const String & filename, SourceLocation location_in_mitsuba_file, float radius);
+	Array<Triangle> load(const String & filename, Allocator * allocator, SourceLocation location_in_mitsuba_file, float radius);
 }

--- a/Src/Assets/Mitsuba/MitsubaLoader.cpp
+++ b/Src/Assets/Mitsuba/MitsubaLoader.cpp
@@ -493,7 +493,7 @@ static MeshDataHandle parse_shape(const XMLNode * node, Allocator * allocator, S
 
 		int shape_index = node->get_child_value_optional("shapeIndex", 0);
 
-		String bvh_filename = Format(allocator).format("{}.shape_{}.bvh"_sv, filename_abs, shape_index);
+		String bvh_filename = Format().format("{}.shape_{}.bvh"_sv, filename_abs, shape_index);
 
 		auto fallback_loader = [&](const String & filename, Allocator * allocator) {
 			Serialized serialized;
@@ -508,7 +508,7 @@ static MeshDataHandle parse_shape(const XMLNode * node, Allocator * allocator, S
 
 		MeshDataHandle mesh_data_handle = scene.asset_manager.add_mesh_data(bvh_filename, bvh_filename, allocator, fallback_loader);
 
-		name = Format(allocator).format("{}_{}"_sv, filename_rel, shape_index);
+		name = Format().format("{}_{}"_sv, filename_rel, shape_index);
 
 		return mesh_data_handle;
 	} else if (type == "hair") {

--- a/Src/Assets/Mitsuba/MitsubaLoader.cpp
+++ b/Src/Assets/Mitsuba/MitsubaLoader.cpp
@@ -34,7 +34,7 @@ using SerializedMap = HashMap<String, Serialized>;
 using MaterialMap   = HashMap<String, MaterialHandle>;
 using TextureMap    = HashMap<String, TextureHandle>;
 
-static TextureHandle parse_texture(const XMLNode * node, TextureMap & texture_map, StringView path, Scene & scene, Vector3 & rgb) {
+static TextureHandle parse_texture(const XMLNode * node, Allocator * allocator, TextureMap & texture_map, StringView path, Scene & scene, Vector3 & rgb) {
 	StringView type = node->get_attribute_value("type");
 
 	if (type == "scale") {
@@ -70,7 +70,7 @@ static TextureHandle parse_texture(const XMLNode * node, TextureMap & texture_ma
 	return TextureHandle { INVALID };
 }
 
-static void parse_rgb_or_texture(const XMLNode * node, const char * name, TextureMap & texture_map, StringView path, Scene & scene, Vector3 & rgb, TextureHandle & texture_handle) {
+static void parse_rgb_or_texture(const XMLNode * node, Allocator * allocator, const char * name, TextureMap & texture_map, StringView path, Scene & scene, Vector3 & rgb, TextureHandle & texture_handle) {
 	const XMLNode * colour = node->get_child_by_name(name);
 	if (colour) {
 		if (colour->tag == "rgb") {
@@ -81,7 +81,7 @@ static void parse_rgb_or_texture(const XMLNode * node, const char * name, Textur
 			rgb.y = Math::gamma_to_linear(rgb.y);
 			rgb.z = Math::gamma_to_linear(rgb.z);
 		} else if (colour->tag == "texture") {
-			texture_handle = parse_texture(colour, texture_map, path, scene, rgb);
+			texture_handle = parse_texture(colour, allocator, texture_map, path, scene, rgb);
 
 			const XMLNode * scale = colour->get_child_by_name("scale");
 			if (scale) {
@@ -159,7 +159,7 @@ static void parse_transform(const XMLNode * node, Vector3 * position, Quaternion
 	Matrix4::decompose(world, position, rotation, scale, forward);
 }
 
-static MaterialHandle parse_material(const XMLNode * node, Scene & scene, const MaterialMap & material_map, TextureMap & texture_map, StringView path) {
+static MaterialHandle parse_material(const XMLNode * node, Allocator * allocator, Scene & scene, const MaterialMap & material_map, TextureMap & texture_map, StringView path) {
 	Material material = { };
 
 	const XMLNode * bsdf;
@@ -248,7 +248,7 @@ static MaterialHandle parse_material(const XMLNode * node, Scene & scene, const 
 	if (inner_bsdf_type == "diffuse") {
 		material.type = Material::Type::DIFFUSE;
 
-		parse_rgb_or_texture(inner_bsdf, "reflectance", texture_map, path, scene, material.diffuse, material.texture_id);
+		parse_rgb_or_texture(inner_bsdf, allocator, "reflectance", texture_map, path, scene, material.diffuse, material.texture_id);
 	} else if (inner_bsdf_type == "conductor" || inner_bsdf_type == "roughconductor") {
 		material.type = Material::Type::CONDUCTOR;
 
@@ -269,7 +269,7 @@ static MaterialHandle parse_material(const XMLNode * node, Scene & scene, const 
 	} else if (inner_bsdf_type == "plastic" || inner_bsdf_type == "roughplastic" || inner_bsdf_type == "roughdiffuse") {
 		material.type = Material::Type::PLASTIC;
 
-		parse_rgb_or_texture(inner_bsdf, "diffuseReflectance", texture_map, path, scene, material.diffuse, material.texture_id);
+		parse_rgb_or_texture(inner_bsdf, allocator, "diffuseReflectance", texture_map, path, scene, material.diffuse, material.texture_id);
 
 		if (inner_bsdf_type == "plastic") {
 			material.linear_roughness = 0.0f;
@@ -279,7 +279,7 @@ static MaterialHandle parse_material(const XMLNode * node, Scene & scene, const 
 	} else if (inner_bsdf_type == "phong") {
 		material.type = Material::Type::PLASTIC;
 
-		parse_rgb_or_texture(inner_bsdf, "diffuseReflectance", texture_map, path, scene, material.diffuse, material.texture_id);
+		parse_rgb_or_texture(inner_bsdf, allocator, "diffuseReflectance", texture_map, path, scene, material.diffuse, material.texture_id);
 
 		float exponent = inner_bsdf->get_child_value_optional("exponent", 1.0f);
 		material.linear_roughness = powf(0.5f * exponent + 1.0f, 0.25f);
@@ -361,7 +361,7 @@ static MaterialHandle parse_material(const XMLNode * node, Scene & scene, const 
 	} else if (inner_bsdf_type == "difftrans") {
 		material.type = Material::Type::DIFFUSE;
 
-		parse_rgb_or_texture(inner_bsdf, "transmittance", texture_map, path, scene, material.diffuse, material.texture_id);
+		parse_rgb_or_texture(inner_bsdf, allocator, "transmittance", texture_map, path, scene, material.diffuse, material.texture_id);
 	} else {
 		WARNING(inner_bsdf->location, "WARNING: BSDF type '{}' not supported!\n", inner_bsdf_type);
 
@@ -533,13 +533,13 @@ static MeshDataHandle parse_shape(const XMLNode * node, Allocator * allocator, S
 
 static void walk_xml_tree(const XMLNode * node, Allocator * allocator, Scene & scene, ShapeGroupMap & shape_group_map, SerializedMap & serialized_map, MaterialMap & material_map, TextureMap & texture_map, StringView path) {
 	if (node->tag == "bsdf") {
-		MaterialHandle material_handle = parse_material(node, scene, material_map, texture_map, path);
+		MaterialHandle material_handle = parse_material(node, allocator, scene, material_map, texture_map, path);
 		const Material & material = scene.asset_manager.get_material(material_handle);
 
 		material_map.insert(material.name, material_handle);
 	} else if (node->tag == "texture") {
 		Vector3 scale = 1.0f;
-		parse_texture(node, texture_map, path, scene, scale);
+		parse_texture(node, allocator, texture_map, path, scene, scale);
 	} else if (node->tag == "shape") {
 		StringView type = node->get_attribute_value<StringView>("type");
 		if (type == "shapegroup") {
@@ -552,7 +552,7 @@ static void walk_xml_tree(const XMLNode * node, Allocator * allocator, Scene & s
 				String name = { };
 
 				MeshDataHandle mesh_data_handle = parse_shape(shape, allocator, scene, serialized_map, path, name);
-				MaterialHandle material_handle  = parse_material(shape, scene, material_map, texture_map, path);
+				MaterialHandle material_handle  = parse_material(shape, allocator, scene, material_map, texture_map, path);
 
 				StringView id = node->get_attribute_value<StringView>("id");
 				shape_group_map[id] = { mesh_data_handle, material_handle };
@@ -574,7 +574,7 @@ static void walk_xml_tree(const XMLNode * node, Allocator * allocator, Scene & s
 			String name = { };
 
 			MeshDataHandle mesh_data_handle = parse_shape(node, allocator, scene, serialized_map, path, name);
-			MaterialHandle material_handle  = parse_material(node, scene, material_map, texture_map, path);
+			MaterialHandle material_handle  = parse_material(node, allocator, scene, material_map, texture_map, path);
 			MediumHandle   medium_handle    = parse_medium(node, scene);
 
 			if (material_handle.handle != INVALID) {
@@ -665,7 +665,7 @@ static void walk_xml_tree(const XMLNode * node, Allocator * allocator, Scene & s
 		}
 	} else if (node->tag == "include") {
 		StringView filename_rel = node->get_attribute_value<StringView>("filename");
-		String     filename_abs = Util::combine_stringviews(path, filename_rel);
+		String     filename_abs = Util::combine_stringviews(path, filename_rel, allocator);
 
 		MitsubaLoader::load(filename_abs, allocator, scene);
 	} else for (int i = 0; i < node->children.size(); i++) {

--- a/Src/Assets/Mitsuba/MitsubaLoader.cpp
+++ b/Src/Assets/Mitsuba/MitsubaLoader.cpp
@@ -493,7 +493,7 @@ static MeshDataHandle parse_shape(const XMLNode * node, Allocator * allocator, S
 
 		int shape_index = node->get_child_value_optional("shapeIndex", 0);
 
-		String bvh_filename = Format().format("{}.shape_{}.bvh"_sv, filename_abs, shape_index);
+		String bvh_filename = Format(allocator).format("{}.shape_{}.bvh"_sv, filename_abs, shape_index);
 
 		auto fallback_loader = [&](const String & filename, Allocator * allocator) {
 			Serialized serialized;
@@ -508,7 +508,7 @@ static MeshDataHandle parse_shape(const XMLNode * node, Allocator * allocator, S
 
 		MeshDataHandle mesh_data_handle = scene.asset_manager.add_mesh_data(bvh_filename, bvh_filename, allocator, fallback_loader);
 
-		name = Format().format("{}_{}"_sv, filename_rel, shape_index);
+		name = Format(allocator).format("{}_{}"_sv, filename_rel, shape_index);
 
 		return mesh_data_handle;
 	} else if (type == "hair") {

--- a/Src/Assets/Mitsuba/MitsubaLoader.cpp
+++ b/Src/Assets/Mitsuba/MitsubaLoader.cpp
@@ -431,7 +431,7 @@ static MediumHandle parse_medium(const XMLNode * node, Scene & scene) {
 	return MediumHandle { INVALID };
 }
 
-static MeshDataHandle parse_shape(const XMLNode * node, Scene & scene, SerializedMap & serialized_map, StringView path, String & name) {
+static MeshDataHandle parse_shape(const XMLNode * node, Allocator * allocator, Scene & scene, SerializedMap & serialized_map, StringView path, String & name) {
 	StringView type = node->get_attribute_value<StringView>("type");
 
 	if (type == "obj" || type == "ply") {
@@ -439,9 +439,9 @@ static MeshDataHandle parse_shape(const XMLNode * node, Scene & scene, Serialize
 
 		MeshDataHandle mesh_data_handle;
 		if (type == "obj") {
-			mesh_data_handle = scene.asset_manager.add_mesh_data(filename, OBJLoader::load);
+			mesh_data_handle = scene.asset_manager.add_mesh_data(filename, allocator, OBJLoader::load);
 		} else {
-			mesh_data_handle = scene.asset_manager.add_mesh_data(filename, PLYLoader::load);
+			mesh_data_handle = scene.asset_manager.add_mesh_data(filename, allocator, PLYLoader::load);
 		}
 
 		name = Util::remove_directory(filename.view());
@@ -495,18 +495,18 @@ static MeshDataHandle parse_shape(const XMLNode * node, Scene & scene, Serialize
 
 		String bvh_filename = Format().format("{}.shape_{}.bvh"_sv, filename_abs, shape_index);
 
-		auto fallback_loader = [&](const String & filename) {
+		auto fallback_loader = [&](const String & filename, Allocator * allocator) {
 			Serialized serialized;
 			bool found = serialized_map.try_get(filename_abs, serialized);
 			if (!found) {
-				serialized = SerializedLoader::load(filename_abs, node->location);
+				serialized = SerializedLoader::load(filename_abs, allocator, node->location);
 				serialized_map[filename_rel] = serialized;
 			}
 
 			return std::move(serialized.meshes[shape_index]);
 		};
 
-		MeshDataHandle mesh_data_handle = scene.asset_manager.add_mesh_data(bvh_filename, bvh_filename, fallback_loader);
+		MeshDataHandle mesh_data_handle = scene.asset_manager.add_mesh_data(bvh_filename, bvh_filename, allocator, fallback_loader);
 
 		name = Format().format("{}_{}"_sv, filename_rel, shape_index);
 
@@ -517,10 +517,10 @@ static MeshDataHandle parse_shape(const XMLNode * node, Scene & scene, Serialize
 
 		float radius = node->get_child_value_optional("radius", 0.0025f);
 
-		auto fallback_loader = [&](const String & filename) {
-			return MitshairLoader::load(filename, node->location, radius);
+		auto fallback_loader = [&](const String & filename, Allocator * allocator) {
+			return MitshairLoader::load(filename, allocator, node->location, radius);
 		};
-		MeshDataHandle mesh_data_handle = scene.asset_manager.add_mesh_data(filename_abs, fallback_loader);
+		MeshDataHandle mesh_data_handle = scene.asset_manager.add_mesh_data(filename_abs, allocator, fallback_loader);
 
 		name = filename_rel;
 
@@ -531,7 +531,7 @@ static MeshDataHandle parse_shape(const XMLNode * node, Scene & scene, Serialize
 	}
 }
 
-static void walk_xml_tree(const XMLNode * node, Scene & scene, ShapeGroupMap & shape_group_map, SerializedMap & serialized_map, MaterialMap & material_map, TextureMap & texture_map, StringView path) {
+static void walk_xml_tree(const XMLNode * node, Allocator * allocator, Scene & scene, ShapeGroupMap & shape_group_map, SerializedMap & serialized_map, MaterialMap & material_map, TextureMap & texture_map, StringView path) {
 	if (node->tag == "bsdf") {
 		MaterialHandle material_handle = parse_material(node, scene, material_map, texture_map, path);
 		const Material & material = scene.asset_manager.get_material(material_handle);
@@ -551,7 +551,7 @@ static void walk_xml_tree(const XMLNode * node, Scene & scene, ShapeGroupMap & s
 
 				String name = { };
 
-				MeshDataHandle mesh_data_handle = parse_shape(shape, scene, serialized_map, path, name);
+				MeshDataHandle mesh_data_handle = parse_shape(shape, allocator, scene, serialized_map, path, name);
 				MaterialHandle material_handle  = parse_material(shape, scene, material_map, texture_map, path);
 
 				StringView id = node->get_attribute_value<StringView>("id");
@@ -573,7 +573,7 @@ static void walk_xml_tree(const XMLNode * node, Scene & scene, ShapeGroupMap & s
 		} else {
 			String name = { };
 
-			MeshDataHandle mesh_data_handle = parse_shape(node, scene, serialized_map, path, name);
+			MeshDataHandle mesh_data_handle = parse_shape(node, allocator, scene, serialized_map, path, name);
 			MaterialHandle material_handle  = parse_material(node, scene, material_map, texture_map, path);
 			MediumHandle   medium_handle    = parse_medium(node, scene);
 
@@ -667,14 +667,14 @@ static void walk_xml_tree(const XMLNode * node, Scene & scene, ShapeGroupMap & s
 		StringView filename_rel = node->get_attribute_value<StringView>("filename");
 		String     filename_abs = Util::combine_stringviews(path, filename_rel);
 
-		MitsubaLoader::load(filename_abs, scene);
+		MitsubaLoader::load(filename_abs, allocator, scene);
 	} else for (int i = 0; i < node->children.size(); i++) {
-		walk_xml_tree(&node->children[i], scene, shape_group_map, serialized_map, material_map, texture_map, path);
+		walk_xml_tree(&node->children[i], allocator, scene, shape_group_map, serialized_map, material_map, texture_map, path);
 	}
 }
 
-void MitsubaLoader::load(const String & filename, Scene & scene) {
-	XMLParser xml_parser(filename);
+void MitsubaLoader::load(const String & filename, Allocator * allocator, Scene & scene) {
+	XMLParser xml_parser(filename, allocator);
 
 	XMLNode root = xml_parser.parse_root();
 
@@ -697,9 +697,9 @@ void MitsubaLoader::load(const String & filename, Scene & scene) {
 		}
 	}
 
-	ShapeGroupMap shape_group_map;
-	SerializedMap serialized_map;
-	MaterialMap   material_map;
-	TextureMap    texture_map;
-	walk_xml_tree(scene_node, scene, shape_group_map, serialized_map, material_map, texture_map, Util::get_directory(filename.view()));
+	ShapeGroupMap shape_group_map(allocator);
+	SerializedMap serialized_map (allocator);
+	MaterialMap   material_map   (allocator);
+	TextureMap    texture_map    (allocator);
+	walk_xml_tree(scene_node, allocator, scene, shape_group_map, serialized_map, material_map, texture_map, Util::get_directory(filename.view()));
 }

--- a/Src/Assets/Mitsuba/MitsubaLoader.h
+++ b/Src/Assets/Mitsuba/MitsubaLoader.h
@@ -4,5 +4,5 @@
 struct Scene;
 
 namespace MitsubaLoader {
-	void load(const String & filename, Scene & scene);
+	void load(const String & filename, Allocator * allocator, Scene & scene);
 }

--- a/Src/Assets/Mitsuba/SerializedLoader.cpp
+++ b/Src/Assets/Mitsuba/SerializedLoader.cpp
@@ -6,8 +6,8 @@
 
 #include "XMLParser.h"
 
-Serialized SerializedLoader::load(const String & filename, SourceLocation location_in_mitsuba_file) {
-	String serialized = IO::file_read(filename);
+Serialized SerializedLoader::load(const String & filename, Allocator * allocator, SourceLocation location_in_mitsuba_file) {
+	String serialized = IO::file_read(filename, allocator);
 	Parser parser(serialized.view(), filename.view());
 
 	uint16_t file_format_id = parser.parse_binary<uint16_t>();
@@ -22,7 +22,7 @@ Serialized SerializedLoader::load(const String & filename, SourceLocation locati
 	uint32_t num_meshes = parser.parse_binary<uint32_t>();
 	uint64_t eof_dictionary_offset = 0;;
 
-	Array<uint64_t> mesh_offsets(num_meshes + 1);
+	Array<uint64_t> mesh_offsets(num_meshes + 1, allocator);
 
 	if (file_version <= 3) {
 		// Version 0.3.0 and earlier use 32 bit mesh offsets

--- a/Src/Assets/Mitsuba/SerializedLoader.h
+++ b/Src/Assets/Mitsuba/SerializedLoader.h
@@ -11,5 +11,5 @@ struct Serialized {
 };
 
 namespace SerializedLoader {
-	Serialized load(const String & filename, SourceLocation location_in_mitsuba_file);
+	Serialized load(const String & filename, Allocator * allocator, SourceLocation location_in_mitsuba_file);
 }

--- a/Src/Assets/Mitsuba/XMLParser.cpp
+++ b/Src/Assets/Mitsuba/XMLParser.cpp
@@ -1,11 +1,26 @@
 #include "XMLParser.h"
 
-inline XMLNode parse_tag(Parser & parser) {
-	if (parser.reached_end()) return { };
+XMLNode XMLParser::parse_root() {
+	XMLNode root = XMLNode(&allocator);
+	root.location = parser.location;
+
+	while (!parser.reached_end()) {
+		parser_skip_xml_whitespace(parser);
+		root.children.push_back(parse_tag());
+		parser_skip_xml_whitespace(parser);
+	}
+
+	return root;
+}
+
+XMLNode XMLParser::parse_tag() {
+	XMLNode node = XMLNode(&allocator);
+	if (parser.reached_end()) {
+		return node;
+	}
 
 	parser.expect('<');
 
-	XMLNode node = { };
 	node.location         = parser.location;
 	node.is_question_mark = parser.match('?');
 
@@ -66,7 +81,7 @@ inline XMLNode parse_tag(Parser & parser) {
 
 	// Parse children
 	while (!parser.match("</")) {
-		node.children.push_back(parse_tag(parser));
+		node.children.push_back(parse_tag());
 		parser_skip_xml_whitespace(parser);
 	}
 
@@ -81,17 +96,4 @@ inline XMLNode parse_tag(Parser & parser) {
 	}
 
 	return node;
-}
-
-XMLNode XMLParser::parse_root() {
-	XMLNode root = { };
-	root.location = parser.location;
-
-	while (!parser.reached_end()) {
-		parser_skip_xml_whitespace(parser);
-		root.children.push_back(parse_tag(parser));
-		parser_skip_xml_whitespace(parser);
-	}
-
-	return root;
 }

--- a/Src/Assets/Mitsuba/XMLParser.cpp
+++ b/Src/Assets/Mitsuba/XMLParser.cpp
@@ -1,7 +1,7 @@
 #include "XMLParser.h"
 
 XMLNode XMLParser::parse_root() {
-	XMLNode root = XMLNode(&allocator);
+	XMLNode root = XMLNode(allocator);
 	root.location = parser.location;
 
 	while (!parser.reached_end()) {
@@ -14,7 +14,7 @@ XMLNode XMLParser::parse_root() {
 }
 
 XMLNode XMLParser::parse_tag() {
-	XMLNode node = XMLNode(&allocator);
+	XMLNode node = XMLNode(allocator);
 	if (parser.reached_end()) {
 		return node;
 	}

--- a/Src/Assets/Mitsuba/XMLParser.h
+++ b/Src/Assets/Mitsuba/XMLParser.h
@@ -4,6 +4,7 @@
 
 #include "Core/Array.h"
 #include "Core/Parser.h"
+#include "Core/Allocators/LinearAllocator.h"
 
 inline void parser_skip_xml_whitespace(Parser & parser) {
 	parser.skip_whitespace_or_newline();
@@ -98,6 +99,13 @@ struct XMLNode {
 
 	SourceLocation location;
 
+	XMLNode(Allocator * allocator) : attributes(allocator), children(allocator) { }
+
+	DEFAULT_MOVEABLE(XMLNode);
+	DEFAULT_COPYABLE(XMLNode);
+
+	~XMLNode() { }
+
 	template<typename Predicate>
 	const XMLAttribute * get_attribute(Predicate predicate) const {
 		for (int i = 0; i < attributes.size(); i++) {
@@ -180,7 +188,12 @@ struct XMLParser {
 	String source;
 	Parser parser;
 
+	LinearAllocator<GIGABYTE(1)> allocator;
+
 	XMLParser(const String & filename) : source(IO::file_read(filename)), parser(source.view(), filename.view()) { }
 
 	XMLNode parse_root();
+
+private:
+	XMLNode parse_tag();
 };

--- a/Src/Assets/Mitsuba/XMLParser.h
+++ b/Src/Assets/Mitsuba/XMLParser.h
@@ -185,12 +185,12 @@ struct XMLNode {
 };
 
 struct XMLParser {
+	Allocator * allocator = nullptr;
+
 	String source;
 	Parser parser;
 
-	LinearAllocator<GIGABYTE(1)> allocator;
-
-	XMLParser(const String & filename) : source(IO::file_read(filename)), parser(source.view(), filename.view()) { }
+	XMLParser(const String & filename, Allocator * allocator) : allocator(allocator), source(IO::file_read(filename, allocator)), parser(source.view(), filename.view()) { }
 
 	XMLNode parse_root();
 

--- a/Src/Assets/OBJLoader.cpp
+++ b/Src/Assets/OBJLoader.cpp
@@ -107,12 +107,19 @@ struct OBJFile {
 	Array<Vector3> normals;
 
 	Array<Face> faces;
+
+	OBJFile(Allocator * allocator = nullptr) : positions(allocator), tex_coords(allocator), normals(allocator), faces(allocator) { }
+
+	DEFAULT_COPYABLE(OBJFile);
+	DEFAULT_MOVEABLE(OBJFile);
+
+	~OBJFile() { }
 };
 
-static OBJFile parse_obj(const String & filename) {
-	String file = IO::file_read(filename);
+static OBJFile parse_obj(const String & filename, Allocator * allocator) {
+	String file = IO::file_read(filename, allocator);
 
-	OBJFile obj = { };
+	OBJFile obj = OBJFile(allocator);
 
 	Parser parser(file.view(), filename.view());
 
@@ -140,8 +147,8 @@ static OBJFile parse_obj(const String & filename) {
 	return obj;
 }
 
-Array<Triangle> OBJLoader::load(const String & filename) {
-	OBJFile obj = parse_obj(filename);
+Array<Triangle> OBJLoader::load(const String & filename, Allocator * allocator) {
+	OBJFile obj = parse_obj(filename, allocator);
 
 	Array<Triangle> triangles(obj.faces.size());
 

--- a/Src/Assets/OBJLoader.h
+++ b/Src/Assets/OBJLoader.h
@@ -4,5 +4,5 @@
 #include "Core/String.h"
 
 namespace OBJLoader {
-	Array<Triangle> load(const String & filename);
+	Array<Triangle> load(const String & filename, Allocator * allocator);
 }

--- a/Src/Assets/PLYLoader.cpp
+++ b/Src/Assets/PLYLoader.cpp
@@ -148,8 +148,8 @@ static T parse_property_value(Parser & parser, Property::Type::Kind kind, PLYFor
 	}
 }
 
-Array<Triangle> PLYLoader::load(const String & filename) {
-	String file = IO::file_read(filename);
+Array<Triangle> PLYLoader::load(const String & filename, Allocator * allocator) {
+	String file = IO::file_read(filename, allocator);
 
 	Parser parser(file.view(), filename.view());
 

--- a/Src/Assets/PLYLoader.h
+++ b/Src/Assets/PLYLoader.h
@@ -5,5 +5,5 @@
 #include "Core/String.h"
 
 namespace PLYLoader {
-	Array<Triangle> load(const String & filename);
+	Array<Triangle> load(const String & filename, Allocator * allocator);
 }

--- a/Src/Assets/TextureLoader.cpp
+++ b/Src/Assets/TextureLoader.cpp
@@ -139,7 +139,8 @@ bool TextureLoader::load_stb(const String & filename, Texture & texture) {
 	int pixel_count = 0;
 	mip_count(texture.width, texture.height, mip_levels, pixel_count);
 
-	Array<Vector4> data_rgba(pixel_count);
+	LinearAllocator<MEGABYTES(8)> allocator;
+	Array<Vector4> data_rgba(pixel_count, &allocator);
 
 	// Copy the data over into Mipmap level 0, and convert it to linear colour space
 	for (int i = 0; i < texture.width * texture.height; i++) {
@@ -167,7 +168,7 @@ bool TextureLoader::load_stb(const String & filename, Texture & texture) {
 
 		int level = 1;
 
-		Array<Vector4> temp((texture.width / 2) * texture.height); // Intermediate storage used when performing seperable filtering
+		Array<Vector4> temp((texture.width / 2) * texture.height, &allocator); // Intermediate storage used when performing seperable filtering
 
 		while (true) {
 			if (cpu_config.mipmap_filter == MipmapFilterType::BOX) {
@@ -214,6 +215,7 @@ bool TextureLoader::load_stb(const String & filename, Texture & texture) {
 		mip_count(new_width, new_height, new_mip_levels, new_pixel_count);
 
 		Array<int> new_mip_offsets;
+		new_mip_offsets.reserve(new_mip_levels);
 
 		constexpr int COMPRESSED_BLOCK_SIZE = 8;
 

--- a/Src/Assets/TextureLoader.cpp
+++ b/Src/Assets/TextureLoader.cpp
@@ -17,7 +17,7 @@
 #include "Util/Util.h"
 
 bool TextureLoader::load_dds(const String & filename, Texture & texture) {
-	StackAllocator<> allocator;
+	StackAllocator<KILOBYTES(8)> allocator;
 	String file = IO::file_read(filename, &allocator);
 	Parser parser(file.view(), filename.view());
 

--- a/Src/Assets/TextureLoader.cpp
+++ b/Src/Assets/TextureLoader.cpp
@@ -11,12 +11,14 @@
 #include "Config.h"
 
 #include "Core/Parser.h"
+#include "Core/Allocators/StackAllocator.h"
 
 #include "Math/Mipmap.h"
 #include "Util/Util.h"
 
 bool TextureLoader::load_dds(const String & filename, Texture & texture) {
-	String file = IO::file_read(filename);
+	StackAllocator<> allocator;
+	String file = IO::file_read(filename, &allocator);
 	Parser parser(file.view(), filename.view());
 
 	// Based on: https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header

--- a/Src/BVH/BVH.h
+++ b/Src/BVH/BVH.h
@@ -103,17 +103,23 @@ struct BVH {
 struct BVH2 final : BVH {
 	Array<BVHNode2> nodes;
 
+	BVH2(Allocator * allocator = nullptr) : nodes(allocator) { }
+
 	size_t node_count() const override { return nodes.size(); }
 };
 
 struct BVH4 final : BVH {
 	Array<BVHNode4> nodes;
 
+	BVH4(Allocator * allocator = nullptr) : nodes(allocator) { }
+
 	size_t node_count() const override{ return nodes.size(); }
 };
 
 struct BVH8 final : BVH {
 	Array<BVHNode8> nodes;
+
+	BVH8(Allocator * allocator = nullptr) : nodes(allocator) { }
 
 	size_t node_count() const override { return nodes.size(); }
 };

--- a/Src/BVH/BVHOptimizer.cpp
+++ b/Src/BVH/BVHOptimizer.cpp
@@ -7,6 +7,7 @@
 #include "Core/MinHeap.h"
 #include "Core/Timer.h"
 #include "Core/Random.h"
+#include "Core/Allocators/LinearAllocator.h"
 
 #include "Util/Util.h"
 
@@ -54,9 +55,9 @@ static void init_parent_indices(const BVH2 & bvh, Array<int> & parent_indices, i
 }
 
 // Produces a single batch consisting of 'batch_size' candidates for reinsertion based on random sampling
-static void select_nodes_random(const BVH2 & bvh, const Array<int> & parent_indices, int batch_size, Array<int> & batch_indices, RNG & rng) {
+static void select_nodes_random(const BVH2 & bvh, const Array<int> & parent_indices, int batch_size, Allocator * allocator, Array<int> & batch_indices, RNG & rng) {
 	size_t offset = 0;
-	Array<int> temp(bvh.nodes.size());
+	Array<int> temp(bvh.nodes.size(), allocator);
 
 	// Identify Nodes that are valid for selection
 	for (size_t i = 2; i < bvh.nodes.size(); i++) {
@@ -69,8 +70,8 @@ static void select_nodes_random(const BVH2 & bvh, const Array<int> & parent_indi
 }
 
 // Produces a single batch consisting of 'batch_size' candidates for reinsertion based on which Nodes have the highest inefficiency measure
-static void select_nodes_measure(const BVH2 & bvh, const Array<int> & parent_indices, int batch_size, Array<int> & batch_indices) {
-	Array<float> costs(bvh.nodes.size());
+static void select_nodes_measure(const BVH2 & bvh, const Array<int> & parent_indices, int batch_size, Allocator * allocator, Array<int> & batch_indices) {
+	Array<float> costs(bvh.nodes.size(), allocator);
 
 	int offset = 0;
 
@@ -95,7 +96,7 @@ static void select_nodes_measure(const BVH2 & bvh, const Array<int> & parent_ind
 	auto cmp = [costs](int a, int b) {
 		return costs[a] > costs[b];
 	};
-	MinHeap<int, decltype(cmp)> heap(cmp);
+	MinHeap<int, decltype(cmp)> heap(cmp, allocator);
 
 	for (int i = 0; i < offset; i++) {
 		heap.insert(batch_indices[i]);
@@ -106,7 +107,7 @@ static void select_nodes_measure(const BVH2 & bvh, const Array<int> & parent_ind
 }
 
 // Finds the global minimum of where best to insert the reinsertion node by traversing the tree using Branch and Bound
-static void find_reinsertion(const BVH2 & bvh, const BVHNode2 & node_reinsert, float & min_cost, int & min_index) {
+static void find_reinsertion(const BVH2 & bvh, const BVHNode2 & node_reinsert, Allocator * allocator, float & min_cost, int & min_index) {
 	float node_reinsert_area = node_reinsert.aabb.surface_area();
 
 	struct Pair {
@@ -118,7 +119,7 @@ static void find_reinsertion(const BVH2 & bvh, const BVHNode2 & node_reinsert, f
 		}
 	};
 
-	MinHeap<Pair> priority_queue;
+	MinHeap<Pair> priority_queue(allocator);
 	priority_queue.emplace(0, 0.0f); // Push BVH root with 0 induced cost
 
 	while (priority_queue.size() > 0) {
@@ -217,11 +218,22 @@ static void bvh_node_calc_axis(BVH2 & bvh, Array<int> & parent_indices, Array<in
 }
 
 void BVHOptimizer::optimize(BVH2 & bvh) {
+	// Calculate the number of BHV Nodes that may be included in a batch
+	// These Nodes must be internal Nodes and must have a grandparent (i.e. cannot be the child of the root)
+	// This means a tree with 7 nodes has 0 batch candidates, and every 2 additional child nodes in the tree account for 1 more batch candidate:
+	int num_batch_candidates = Math::max<int>((bvh.nodes.size() - 7) / 2, 0);
+	if (num_batch_candidates < 8) {
+		return; // Too small to optimize
+	}
+
 	ScopeTimer timer("BVH Optimization"_sv);
 
 	float cost_before = bvh_sah_cost(bvh);
 
-	Array<int> parent_indices(bvh.nodes.size());
+	LinearAllocator<MEGABYTES(1)> init_allocator; // Memory used during the entire optimization process
+	LinearAllocator<MEGABYTES(1)> loop_allocator; // Memory reset every batch iteration
+
+	Array<int> parent_indices(bvh.nodes.size(), &init_allocator);
 	parent_indices[0] = -1; // Root has no parent
 	init_parent_indices(bvh, parent_indices);
 
@@ -231,16 +243,8 @@ void BVHOptimizer::optimize(BVH2 & bvh) {
 
 	static_assert(P_T >= P_R);
 
-	// Calculate the number of BHV Nodes that may be included in a batch
-	// These Nodes must be internal Nodes and must have a grandparent (i.e. cannot be the child of the root)
-	// This means a tree with 7 nodes has 0 batch candidates, and every 2 additional child nodes in the tree account for 1 more batch candidate:
-	int num_batch_candidates = Math::max<int>((bvh.nodes.size() - 7) / 2, 0);
-	if (num_batch_candidates < 8) {
-		return; // Too small to optimize
-	}
-
 	int        batch_size = Math::max<int>(bvh.nodes.size() / k, num_batch_candidates);
-	Array<int> batch_indices(bvh.nodes.size());
+	Array<int> batch_indices(bvh.nodes.size(), &init_allocator);
 
 	int batch_count = 0;
 	int batches_since_last_cost_reduction = 0;
@@ -252,19 +256,20 @@ void BVHOptimizer::optimize(BVH2 & bvh) {
 		MEASURE
 	} node_selection_method = NodeSelectionMethod::MEASURE;
 
-	Array<int> originated  (bvh.nodes.size());
-	Array<int> displacement(bvh.nodes.size());
+	Array<int> originated  (bvh.nodes.size(), &init_allocator);
+	Array<int> displacement(bvh.nodes.size(), &init_allocator);
 
 	RNG rng(time(nullptr));
 
 	clock_t start_time = clock();
 
 	while (true) {
+//		loop_allocator.reset();
+
 		// Select a batch of internal Nodes, either randomly or using a heuristic measure
 		switch (node_selection_method) {
-			case NodeSelectionMethod::RANDOM:  select_nodes_random (bvh, parent_indices, batch_size, batch_indices, rng); break;
-			case NodeSelectionMethod::MEASURE: select_nodes_measure(bvh, parent_indices, batch_size, batch_indices); break;
-
+			case NodeSelectionMethod::RANDOM:  select_nodes_random (bvh, parent_indices, batch_size, &loop_allocator, batch_indices, rng); break;
+			case NodeSelectionMethod::MEASURE: select_nodes_measure(bvh, parent_indices, batch_size, &loop_allocator, batch_indices);      break;
 			default: ASSERT_UNREACHABLE();
 		}
 
@@ -340,7 +345,7 @@ void BVHOptimizer::optimize(BVH2 & bvh) {
 				float min_cost  = INFINITY;
 				int   min_index = -1;
 
-				find_reinsertion(bvh, reinsert.node, min_cost, min_index);
+				find_reinsertion(bvh, reinsert.node, &loop_allocator, min_cost, min_index);
 
 				// Bookkeeping updates to perform the reinsertion
 				bvh.nodes[unused    ] = bvh.nodes[min_index];

--- a/Src/BVH/BVHOptimizer.cpp
+++ b/Src/BVH/BVHOptimizer.cpp
@@ -264,7 +264,7 @@ void BVHOptimizer::optimize(BVH2 & bvh) {
 	clock_t start_time = clock();
 
 	while (true) {
-//		loop_allocator.reset();
+		loop_allocator.reset();
 
 		// Select a batch of internal Nodes, either randomly or using a heuristic measure
 		switch (node_selection_method) {

--- a/Src/Core/Allocators/Allocator.h
+++ b/Src/Core/Allocators/Allocator.h
@@ -3,9 +3,9 @@
 
 #include "Util/Util.h"
 
-#define KILOBYTE(n) (n * 1024)
-#define MEGABYTE(n) (n * 1024 * 1024)
-#define GIGABYTE(n) (n * 1024 * 1024 * 1024)
+#define KILOBYTES(n) ((n) * 1024)
+#define MEGABYTES(n) ((n) * 1024 * 1024)
+#define GIGABYTES(n) ((n) * 1024 * 1024 * 1024)
 
 struct Allocator {
 	Allocator() = default;

--- a/Src/Core/Allocators/Allocator.h
+++ b/Src/Core/Allocators/Allocator.h
@@ -1,0 +1,57 @@
+#pragma once
+#include <new>
+
+#include "Util/Util.h"
+
+#define KILOBYTE(n) (n * 1024)
+#define MEGABYTE(n) (n * 1024 * 1024)
+#define GIGABYTE(n) (n * 1024 * 1024 * 1024)
+
+struct Allocator {
+	Allocator() = default;
+
+	NON_COPYABLE(Allocator);
+	NON_MOVEABLE(Allocator);
+
+	virtual ~Allocator() { }
+
+	template<typename T, typename ... Args>
+	static T * alloc(Allocator * allocator, Args && ... args) {
+		if (allocator) {
+			return new (allocator->alloc(sizeof(T))) T { std::forward<Args>(args) ... };
+		} else {
+			return new T { std::forward<Args>(args) ... };
+		}
+	}
+
+	template<typename T, typename ... Args>
+	static T * alloc_array(Allocator * allocator, size_t count) {
+		if (allocator) {
+			return new (allocator->alloc(count * sizeof(T))) T[count];
+		} else {
+			return new T[count];
+		}
+	}
+
+	template<typename T>
+	static void free(Allocator * allocator, T * ptr) {
+		if (allocator) {
+			allocator->free(ptr);
+		} else {
+			delete ptr;
+		}
+	}
+
+	template<typename T>
+	static void free_array(Allocator * allocator, T * ptr) {
+		if (allocator) {
+			allocator->free(ptr);
+		} else {
+			delete [] ptr;
+		}
+	}
+
+protected:
+	virtual char * alloc(size_t num_bytes) = 0;
+	virtual void   free (void * ptr)       = 0;
+};

--- a/Src/Core/Allocators/Allocator.h
+++ b/Src/Core/Allocators/Allocator.h
@@ -3,6 +3,7 @@
 
 #include "Util/Util.h"
 
+#define BYTES(n) (n)
 #define KILOBYTES(n) ((n) * 1024)
 #define MEGABYTES(n) ((n) * 1024 * 1024)
 #define GIGABYTES(n) ((n) * 1024 * 1024 * 1024)

--- a/Src/Core/Allocators/Allocator.h
+++ b/Src/Core/Allocators/Allocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <new>
 
-#include "Util/Util.h"
+#include "Core/Constructors.h"
 
 #define BYTES(n) (n)
 #define KILOBYTES(n) ((n) * 1024)

--- a/Src/Core/Allocators/LinearAllocator.h
+++ b/Src/Core/Allocators/LinearAllocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Allocator.h"
 
-template<size_t Size = MEGABYTE(4)>
+template<size_t Size = MEGABYTES(4)>
 struct LinearAllocator final : Allocator {
 	char * data   = nullptr;
 	size_t offset = 0;
@@ -19,6 +19,13 @@ struct LinearAllocator final : Allocator {
 		delete [] data;
 		if (next) {
 			next->~LinearAllocator();
+		}
+	}
+
+	void reset() {
+		offset = 0;
+		if (next) {
+			next->reset();
 		}
 	}
 

--- a/Src/Core/Allocators/LinearAllocator.h
+++ b/Src/Core/Allocators/LinearAllocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Allocator.h"
 
-template<size_t Size = MEGABYTES(4)>
+template<size_t Size>
 struct LinearAllocator final : Allocator {
 	char * data   = nullptr;
 	size_t offset = 0;

--- a/Src/Core/Allocators/LinearAllocator.h
+++ b/Src/Core/Allocators/LinearAllocator.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "Allocator.h"
+
+template<size_t Size = MEGABYTE(4)>
+struct LinearAllocator final : Allocator {
+	char * data   = nullptr;
+	size_t offset = 0;
+	LinearAllocator<Size> * next = nullptr;
+
+	LinearAllocator() {
+		data = new char[Size];
+	}
+
+	~LinearAllocator() {
+		ASSERT(data);
+		delete [] data;
+		if (next) {
+			next->~LinearAllocator();
+		}
+	}
+
+	char * alloc(size_t num_bytes) override {
+		if (num_bytes >= Size) {
+			return new char[num_bytes]; // Fall back to heap allocation
+		}
+		if (offset + num_bytes <= Size) {
+			char * result = data + offset;
+			offset += num_bytes;
+			return result;
+		} else if (!next) {
+			next = new LinearAllocator();
+		}
+		return next->alloc(num_bytes);
+	}
+
+	void free(void * ptr) override {
+		if (ptr >= data && ptr < data + Size) {
+			// Do nothing, memory will be freed in bulk inside the destructor
+		} else if (next) {
+			next->free(ptr);
+		} else {
+			delete [] ptr; // ptr was not in any valid range, must have been a heap allocated pointer
+		}
+	}
+};

--- a/Src/Core/Allocators/LinearAllocator.h
+++ b/Src/Core/Allocators/LinearAllocator.h
@@ -11,6 +11,9 @@ struct LinearAllocator final : Allocator {
 		data = new char[Size];
 	}
 
+	NON_COPYABLE(LinearAllocator);
+	NON_MOVEABLE(LinearAllocator);
+
 	~LinearAllocator() {
 		ASSERT(data);
 		delete [] data;
@@ -19,6 +22,7 @@ struct LinearAllocator final : Allocator {
 		}
 	}
 
+private:
 	char * alloc(size_t num_bytes) override {
 		if (num_bytes >= Size) {
 			return new char[num_bytes]; // Fall back to heap allocation

--- a/Src/Core/Allocators/LinearAllocator.h
+++ b/Src/Core/Allocators/LinearAllocator.h
@@ -1,6 +1,10 @@
 #pragma once
 #include "Allocator.h"
 
+// Linear burn-through Allocator
+// Every new allocation simply increases the offset within the buffer by the desired number of bytes
+// Once a buffer runs out, a new buffer is allocated in a linked-list fashion
+// Memory is freed in bulk at the end of the lifetime of the LinearAllocator
 template<size_t Size>
 struct LinearAllocator final : Allocator {
 	char * data   = nullptr;

--- a/Src/Core/Allocators/PinnedAllocator.h
+++ b/Src/Core/Allocators/PinnedAllocator.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Allocator.h"
+
+#include "Device/CUDAMemory.h"
+
+struct PinnedAllocator final : Allocator {
+	char * alloc(size_t num_bytes) override {
+		return CUDAMemory::malloc_pinned<char>(num_bytes);
+	}
+
+	void free(void * ptr) override {
+		CUDAMemory::free_pinned(ptr);
+	}
+
+	static PinnedAllocator * instance() {
+		static PinnedAllocator allocator = { };
+		return &allocator;
+	}
+};

--- a/Src/Core/Allocators/PinnedAllocator.h
+++ b/Src/Core/Allocators/PinnedAllocator.h
@@ -4,6 +4,9 @@
 #include "Device/CUDAMemory.h"
 
 struct PinnedAllocator final : Allocator {
+private:
+	PinnedAllocator() { }
+
 	char * alloc(size_t num_bytes) override {
 		return CUDAMemory::malloc_pinned<char>(num_bytes);
 	}
@@ -12,6 +15,7 @@ struct PinnedAllocator final : Allocator {
 		CUDAMemory::free_pinned(ptr);
 	}
 
+public:
 	static PinnedAllocator * instance() {
 		static PinnedAllocator allocator = { };
 		return &allocator;

--- a/Src/Core/Allocators/PinnedAllocator.h
+++ b/Src/Core/Allocators/PinnedAllocator.h
@@ -3,6 +3,10 @@
 
 #include "Device/CUDAMemory.h"
 
+// Allocator that allocates CUDA pinned memory
+// This is memory that is guarenteed not to be paged out by the OS
+// This memory should be used to upload data to the GPU
+// See: https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/
 struct PinnedAllocator final : Allocator {
 private:
 	PinnedAllocator() { }

--- a/Src/Core/Allocators/StackAllocator.h
+++ b/Src/Core/Allocators/StackAllocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Allocator.h"
 
-template<size_t Size = KILOBYTES(4)>
+template<size_t Size>
 struct StackAllocator final : Allocator {
 	Allocator * fallback_allocator = nullptr;
 

--- a/Src/Core/Allocators/StackAllocator.h
+++ b/Src/Core/Allocators/StackAllocator.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Allocator.h"
 
-template<size_t Size = KILOBYTE(4)>
+template<size_t Size = KILOBYTES(4)>
 struct StackAllocator final : Allocator {
 	Allocator * fallback_allocator = nullptr;
 

--- a/Src/Core/Allocators/StackAllocator.h
+++ b/Src/Core/Allocators/StackAllocator.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "Allocator.h"
+
+template<size_t Size = KILOBYTE(4)>
+struct StackAllocator final : Allocator {
+	Allocator * fallback_allocator = nullptr;
+
+	size_t offset = 0;
+	char data[Size];
+
+	StackAllocator(Allocator * fallback_allocator = nullptr) : fallback_allocator(fallback_allocator) { }
+
+	NON_COPYABLE(StackAllocator);
+	NON_MOVEABLE(StackAllocator);
+
+	~StackAllocator() = default;
+
+private:
+	char * alloc(size_t num_bytes) override {
+		if (offset + num_bytes <= Size) {
+			char * result = data + offset;
+			offset += num_bytes;
+			return result;
+		} else {
+			return Allocator::alloc_array<char>(fallback_allocator, num_bytes);
+		}
+	}
+
+	void free(void * ptr) override {
+		if (ptr >= data && ptr < data + Size) {
+			// Do nothing, memory will be freed in bulk inside the destructor
+		} else {
+			Allocator::free_array(fallback_allocator, ptr);
+		}
+	}
+};

--- a/Src/Core/Allocators/StackAllocator.h
+++ b/Src/Core/Allocators/StackAllocator.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "Allocator.h"
 
+// Linear burn-through Allocator that uses a small in-situ buffer that resides on the program stack
+// A fallback Allocator can be provided when the StackAllocator runs out of space
 template<size_t Size>
 struct StackAllocator final : Allocator {
 	Allocator * fallback_allocator = nullptr;
@@ -28,7 +30,7 @@ private:
 
 	void free(void * ptr) override {
 		if (ptr >= data && ptr < data + Size) {
-			// Do nothing, memory will be freed in bulk inside the destructor
+			// Do nothing
 		} else {
 			Allocator::free_array(fallback_allocator, ptr);
 		}

--- a/Src/Core/Array.h
+++ b/Src/Core/Array.h
@@ -6,20 +6,20 @@
 #include <initializer_list>
 
 #include "Assertion.h"
+#include "Allocators/Allocator.h"
 
 template<typename T>
 struct Array {
-	using value_type      = T;
-	using reference       = T &;
-	using const_reference = const T &;
-	using size_type       = size_t;
-
 	char * buffer = nullptr;
 
 	size_t count    = 0;
 	size_t capacity = 0;
 
-	constexpr Array(size_t initial_count = 0) {
+	Allocator * allocator = nullptr;
+
+	constexpr Array(Allocator * allocator) : allocator(allocator) { }
+
+	constexpr Array(size_t initial_count = 0, Allocator * allocator = nullptr) : allocator(allocator) {
 		resize(initial_count);
 	}
 
@@ -32,11 +32,8 @@ struct Array {
 		}
 	}
 
-	~Array() {
-		destroy_buffer();
-	}
-
 	constexpr Array(const Array & array) {
+		allocator = array.allocator;
 		resize(array.count);
 		for (size_t i = 0; i < count; i++) {
 			data()[i] = array.data()[i];
@@ -44,6 +41,7 @@ struct Array {
 	}
 
 	constexpr Array & operator=(const Array & array) {
+		allocator = array.allocator;
 		resize(array.count);
 		for (size_t i = 0; i < count; i++) {
 			data()[i] = array.data()[i];
@@ -52,9 +50,10 @@ struct Array {
 	}
 
 	constexpr Array(Array && array) noexcept {
-		buffer   = array.buffer;
-		count    = array.count;
-		capacity = array.capacity;
+		buffer    = array.buffer;
+		count     = array.count;
+		capacity  = array.capacity;
+		allocator = array.allocator;
 
 		array.buffer   = nullptr;
 		array.count    = 0;
@@ -64,15 +63,20 @@ struct Array {
 	constexpr Array & operator=(Array && array) noexcept {
 		destroy_buffer();
 
-		buffer   = array.buffer;
-		count    = array.count;
-		capacity = array.capacity;
+		buffer    = array.buffer;
+		count     = array.count;
+		capacity  = array.capacity;
+		allocator = array.allocator;
 
 		array.buffer   = nullptr;
 		array.count    = 0;
 		array.capacity = 0;
 
 		return *this;
+	}
+
+	~Array() {
+		destroy_buffer();
 	}
 
 	constexpr T & push_back(T element) {
@@ -94,7 +98,7 @@ struct Array {
 	constexpr void resize(size_t new_count) {
 		if (new_count == count) return;
 
-		char * new_buffer = new char[new_count * sizeof(T)];
+		char * new_buffer = Allocator::alloc_array<char>(allocator, new_count * sizeof(T));
 
 		if (buffer) {
 			size_t num_move = std::min(count, new_count);
@@ -113,7 +117,7 @@ struct Array {
 				}
 			}
 
-			delete [] buffer;
+			Allocator::free_array(allocator, buffer);
 		}
 		buffer = new_buffer;
 
@@ -137,7 +141,7 @@ struct Array {
 	constexpr void reserve(size_t new_capacity) {
 		if (new_capacity <= capacity) return;
 
-		char * new_buffer = new char[new_capacity * sizeof(T)];
+		char * new_buffer = Allocator::alloc_array<char>(allocator, new_capacity * sizeof(T));
 
 		if (buffer) {
 			if constexpr (std::is_trivially_copyable_v<T>) {
@@ -148,7 +152,7 @@ struct Array {
 					data()[i].~T();
 				}
 			}
-			delete [] buffer;
+			Allocator::free_array(allocator, buffer);
 		}
 		buffer = new_buffer;
 
@@ -204,7 +208,7 @@ private:
 				}
 			}
 
-			delete [] buffer;
+			Allocator::free_array(allocator, buffer);
 			buffer = nullptr;
 		}
 	}

--- a/Src/Core/Constructors.h
+++ b/Src/Core/Constructors.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#define NON_COPYABLE(Name)                   \
+	Name(const Name &)             = delete; \
+	Name & operator=(const Name &) = delete;
+#define NON_MOVEABLE(Name)              \
+	Name(Name &&)             = delete; \
+	Name & operator=(Name &&) = delete;
+
+#define DEFAULT_COPYABLE(Name)                \
+	Name(const Name &)             = default; \
+	Name & operator=(const Name &) = default;
+#define DEFAULT_MOVEABLE(Name)           \
+	Name(Name &&)             = default; \
+	Name & operator=(Name &&) = default;

--- a/Src/Core/Format.h
+++ b/Src/Core/Format.h
@@ -44,7 +44,7 @@ struct Format {
 		ASSERT(spec.fmt_end != fmt.end);
 		append(StringView { fmt.start, spec.fmt_end });
 
-		String str = Formatter<Arg>::format(spec, arg);
+		String str = Formatter<Arg>::format(spec, data.allocator, arg);
 
 		if (spec.align == 0) {
 			spec.align = '<'; // Default for non-integer/float
@@ -95,14 +95,14 @@ struct Formatter {
 
 template<size_t N, typename T>
 struct Formatter<T[N]> {
-	static String format(Format::Spec & fmt_spec, const T * value) {
-		return Formatter<const T *>::format(fmt_spec, value);
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, const T * value) {
+		return Formatter<const T *>::format(fmt_spec, allocator, value);
 	}
 };
 
 template<>
 struct Formatter<char> {
-	static String format(Format::Spec & fmt_spec, char value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, char value) {
 		if (fmt_spec.type == 'd') {
 			if (fmt_spec.align == 0) {
 				fmt_spec.align = '>';
@@ -116,42 +116,42 @@ struct Formatter<char> {
 
 template<>
 struct Formatter<StringView> {
-	static String format(Format::Spec & fmt_spec, StringView value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, StringView value) {
 		return value;
 	}
 };
 
 template<>
 struct Formatter<String> {
-	static String format(Format::Spec & fmt_spec, const String & value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, const String & value) {
 		return value;
 	}
 };
 
 template<>
 struct Formatter<const char *> {
-	static String format(Format::Spec & fmt_spec, const char * value) {
-		return value;
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, const char * value) {
+		return String(value, allocator);
 	}
 };
 
 template<>
 struct Formatter<bool> {
-	static String format(Format::Spec & fmt_spec, bool value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, bool value) {
 		if (fmt_spec.type == 'd') {
 			if (fmt_spec.align == 0) {
 				fmt_spec.align = '>';
 			}
-			return value ? "1"_sv : "0"_sv;
+			return String(value ? "1"_sv : "0"_sv, allocator);
 		} else {
-			return Util::to_string(value);
+			return Util::to_string(value, allocator);
 		}
 	}
 };
 
 template<>
 struct Formatter<int64_t> {
-	static String format(Format::Spec & fmt_spec, int64_t value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, int64_t value) {
 		if (fmt_spec.align == 0) {
 			fmt_spec.align = '>';
 		}
@@ -163,20 +163,20 @@ struct Formatter<int64_t> {
 			base = 16;
 		}
 
-		return Util::to_string(value, base);
+		return Util::to_string(value, base, allocator);
 	}
 };
 
 template<>
 struct Formatter<int> {
-	static String format(Format::Spec & fmt_spec, int value) {
-		return Formatter<int64_t>::format(fmt_spec, value);
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, int value) {
+		return Formatter<int64_t>::format(fmt_spec, allocator, value);
 	}
 };
 
 template<>
 struct Formatter<uint64_t> {
-	static String format(Format::Spec & fmt_spec, uint64_t value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, uint64_t value) {
 		if (fmt_spec.align == 0) {
 			fmt_spec.align = '>';
 		}
@@ -188,33 +188,33 @@ struct Formatter<uint64_t> {
 			base = 16;
 		}
 
-		return Util::to_string(value, base);
+		return Util::to_string(value, base, allocator);
 	}
 };
 
 template<>
 struct Formatter<unsigned> {
-	static String format(Format::Spec & fmt_spec, unsigned value) {
-		return Formatter<int64_t>::format(fmt_spec, value);
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, unsigned value) {
+		return Formatter<int64_t>::format(fmt_spec, allocator, value);
 	}
 };
 
 template<>
 struct Formatter<double> {
-	static String format(Format::Spec & fmt_spec, double value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, double value) {
 		if (fmt_spec.align == 0) {
 			fmt_spec.align = '>';
 		}
-		return Util::to_string(value);
+		return Util::to_string(value, allocator);
 	}
 };
 
 template<>
 struct Formatter<float> {
-	static String format(Format::Spec & fmt_spec, float value) {
+	static String format(Format::Spec & fmt_spec, Allocator * allocator, float value) {
 		if (fmt_spec.align == 0) {
 			fmt_spec.align = '>';
 		}
-		return Util::to_string(double(value));
+		return Util::to_string(double(value), allocator);
 	}
 };

--- a/Src/Core/Format.h
+++ b/Src/Core/Format.h
@@ -25,6 +25,13 @@ struct Format {
 
 	Array<char> data;
 
+	Format(Allocator * allocator = nullptr) : data(allocator) { }
+
+	NON_COPYABLE(Format);
+	NON_MOVEABLE(Format);
+
+	~Format() { }
+
 	String format(StringView fmt) {
 		append(fmt);
 		append('\0');

--- a/Src/Core/IO.cpp
+++ b/Src/Core/IO.cpp
@@ -17,7 +17,7 @@ bool IO::file_is_newer(StringView filename_a, StringView filename_b) {
 	return last_write_time_filename_a < last_write_time_filename_b;
 }
 
-String IO::file_read(const String & filename) {
+String IO::file_read(const String & filename, Allocator * allocator) {
 	FILE * file = nullptr;
 	fopen_s(&file, filename.data(), "rb");
 
@@ -28,7 +28,7 @@ String IO::file_read(const String & filename) {
 
 	size_t file_length = std::filesystem::file_size(stringview_to_path(filename.view()));
 
-	String data(file_length);
+	String data(file_length, allocator);
 	fread_s(data.data(), file_length, 1, file_length, file);
 	data.data()[file_length] = '\0';
 

--- a/Src/Core/IO.h
+++ b/Src/Core/IO.h
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include "Format.h"
+#include "Allocators/LinearAllocator.h"
 
 namespace IO {
 	inline void print(char c) {
@@ -14,7 +15,8 @@ namespace IO {
 
 	template<typename ... Args>
 	inline void print(StringView fmt, const Args & ... args) {
-		String string = Format().format(fmt, args ...);
+		LinearAllocator<KILOBYTE(4)> allocator;
+		String string = Format(&allocator).format(fmt, args ...);
 		print(string.view());
 	}
 

--- a/Src/Core/IO.h
+++ b/Src/Core/IO.h
@@ -15,7 +15,7 @@ namespace IO {
 
 	template<typename ... Args>
 	inline void print(StringView fmt, const Args & ... args) {
-		LinearAllocator<KILOBYTE(4)> allocator;
+		LinearAllocator<KILOBYTES(4)> allocator;
 		String string = Format(&allocator).format(fmt, args ...);
 		print(string.view());
 	}
@@ -30,6 +30,6 @@ namespace IO {
 
 	bool file_is_newer(StringView filename_a, StringView filename_b);
 
-	String file_read (const String & filename);
+	String file_read (const String & filename, Allocator * allocator);
 	bool   file_write(const String & filename, StringView data);
 }

--- a/Src/Core/MinHeap.h
+++ b/Src/Core/MinHeap.h
@@ -7,7 +7,7 @@ struct MinHeap {
 	Array<T> data;
 	Cmp cmp;
 
-	constexpr MinHeap(Cmp cmp = { }) : cmp(cmp) { }
+	constexpr MinHeap(Cmp cmp = { }, Allocator * allocator = nullptr) : data(allocator), cmp(cmp) { }
 
 	constexpr void insert(T item) {
 		size_t size = data.size();

--- a/Src/Core/MinHeap.h
+++ b/Src/Core/MinHeap.h
@@ -7,6 +7,7 @@ struct MinHeap {
 	Array<T> data;
 	Cmp cmp;
 
+	constexpr MinHeap               (Allocator * allocator = nullptr) : data(allocator) { }
 	constexpr MinHeap(Cmp cmp = { }, Allocator * allocator = nullptr) : data(allocator), cmp(cmp) { }
 
 	constexpr void insert(T item) {

--- a/Src/Core/OwnPtr.h
+++ b/Src/Core/OwnPtr.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Assertion.h"
+#include "Constructors.h"
 
 template<typename T>
 struct OwnPtr {
@@ -11,7 +12,7 @@ struct OwnPtr {
 
 	explicit OwnPtr(T * ptr) : ptr(ptr) { }
 
-	OwnPtr(const OwnPtr & other) = delete;
+	NON_COPYABLE(OwnPtr);
 
 	OwnPtr(OwnPtr && other) noexcept {
 		ptr = other.ptr;
@@ -37,15 +38,6 @@ struct OwnPtr {
 
 	      T * get()       { return ptr; }
 	const T * get() const { return ptr; }
-
-	OwnPtr & operator=(const OwnPtr & other) = delete;
-
-	OwnPtr & operator=(OwnPtr && other) noexcept {
-		release();
-		ptr = other.ptr;
-		other.ptr = nullptr;
-		return *this;
-	}
 
 	template<typename S>
 	OwnPtr & operator=(OwnPtr<S> && other) {

--- a/Src/Core/String.h
+++ b/Src/Core/String.h
@@ -19,21 +19,21 @@ struct String {
 
 	constexpr String(Allocator * allocator) : allocator(allocator), length(0), ptr(nullptr) { }
 
-	constexpr String(size_t length) : length(length), ptr(nullptr) {
+	constexpr String(size_t length, Allocator * allocator = nullptr) : allocator(allocator), length(length), ptr(nullptr) {
 		if (length >= SSO_SIZE) {
 			ptr = Allocator::alloc_array<char>(allocator, length + 1);
 		}
 		data()[0] = '\0';
 	}
 
-	constexpr String(const char * str) : length(strlen(str)), ptr(nullptr) {
+	constexpr String(const char * str, Allocator * allocator = nullptr) : allocator(allocator), length(strlen(str)), ptr(nullptr) {
 		if (length >= SSO_SIZE) {
 			ptr = Allocator::alloc_array<char>(allocator, length + 1);
 		}
 		memcpy(data(), str, length + 1);
 	}
 
-	constexpr String(const char * str, size_t len) : length(len), ptr(nullptr) {
+	constexpr String(const char * str, size_t len, Allocator * allocator = nullptr) : allocator(allocator), length(len), ptr(nullptr) {
 		if (length >= SSO_SIZE) {
 			ptr = Allocator::alloc_array<char>(allocator, length + 1);
 		}
@@ -41,10 +41,10 @@ struct String {
 		data()[length] = '\0';
 	}
 
-	constexpr String(const StringView & str) : String(str.start, str.length()) { }
+	constexpr String(const StringView & str, Allocator * allocator = nullptr) : String(str.start, str.length(), allocator) { }
 
 	template<size_t N>
-	constexpr String(const char (& str)[N]) : length(N - 1), ptr(nullptr) {
+	constexpr String(const char (& str)[N], Allocator * allocator = nullptr) : allocator(allocator), length(N - 1), ptr(nullptr) {
 		if (length >= SSO_SIZE) {
 			ptr = Allocator::alloc_array<char>(allocator, length + 1);
 		}

--- a/Src/Device/CUDAModule.cpp
+++ b/Src/Device/CUDAModule.cpp
@@ -32,8 +32,8 @@ struct Include {
 // Collects filename and source of included files in 'includes'
 // Also check whether any included file has been modified since last compilation and if so sets 'should_recompile'
 // Returns source code of 'filename'
-static String scan_includes_recursive(const String & filename, StringView directory, Array<Include> & includes, StringView ptx_filename, bool & should_recompile) {
-	String source = IO::file_read(filename);
+static String scan_includes_recursive(const String & filename, Allocator * allocator, StringView directory, Array<Include> & includes, StringView ptx_filename, bool & should_recompile) {
+	String source = IO::file_read(filename, allocator);
 	Parser parser(source.view(), filename.view());
 
 	while (!parser.reached_end()) {
@@ -70,7 +70,7 @@ static String scan_includes_recursive(const String & filename, StringView direct
 
 			// If we haven't seen this include before, recurse
 			if (unseen_include) {
-				String include_full_path = Util::combine_stringviews(directory, include_filename);
+				String include_full_path = Util::combine_stringviews(directory, include_filename, allocator);
 
 				if (IO::file_exists(include_full_path.view())) {
 					if (!should_recompile && IO::file_is_newer(ptx_filename, include_full_path.view())) {
@@ -84,8 +84,8 @@ static String scan_includes_recursive(const String & filename, StringView direct
 					size_t index = includes.size();
 					includes.emplace_back();
 
-					includes[index].filename = String(include_filename);
-					includes[index].source   = scan_includes_recursive(include_full_path, path, includes, ptx_filename, should_recompile);
+					includes[index].filename = String(include_filename, allocator);
+					includes[index].source   = scan_includes_recursive(include_full_path, allocator, path, includes, ptx_filename, should_recompile);
 				}
 			}
 		} else {
@@ -120,16 +120,18 @@ void CUDAModule::init(const String & module_name, const String & filename, int c
 
 	StringView path = Util::get_directory(filename.view());
 
+	LinearAllocator<KILOBYTES(512)> allocator;
+
 	Array<Include> includes;
-	String source = scan_includes_recursive(filename, path, includes, ptx_filename.view(), should_recompile);
+	String source = scan_includes_recursive(filename, &allocator, path, includes, ptx_filename.view(), should_recompile);
 
 	if (should_recompile) {
 		nvrtcProgram program;
 
 		while (true) {
 			size_t num_includes = includes.size();
-			Array<const char *> include_names  (num_includes);
-			Array<const char *> include_sources(num_includes);
+			Array<const char *> include_names  (num_includes, &allocator);
+			Array<const char *> include_sources(num_includes, &allocator);
 
 			for (size_t i = 0; i < num_includes; i++) {
 				include_names  [i] = includes[i].filename.data();
@@ -140,8 +142,8 @@ void CUDAModule::init(const String & module_name, const String & filename, int c
 			NVRTC_CALL(nvrtcCreateProgram(&program, source.data(), module_name.c_str(), int(num_includes), include_sources.data(), include_names.data()));
 
 			// Configure options
-			String option_compute = Format().format("--gpu-architecture=compute_{}"_sv, compute_capability);
-			String option_maxregs = Format().format("--maxrregcount={}"_sv, max_registers);
+			String option_compute = Format(&allocator).format("--gpu-architecture=compute_{}"_sv, compute_capability);
+			String option_maxregs = Format(&allocator).format("--maxrregcount={}"_sv, max_registers);
 
 			const char * options[] = {
 				"--std=c++11",
@@ -161,7 +163,7 @@ void CUDAModule::init(const String & module_name, const String & filename, int c
 			NVRTC_CALL(nvrtcGetProgramLogSize(program, &log_size));
 
 			if (log_size > 1) {
-				String log(log_size);
+				String log(log_size, &allocator);
 				NVRTC_CALL(nvrtcGetProgramLog(program, log.data()));
 
 				IO::print("NVRTC output:\n{}\n"_sv, log);
@@ -172,8 +174,9 @@ void CUDAModule::init(const String & module_name, const String & filename, int c
 			__debugbreak(); // Compile error
 
 			// Reload file and try again
+			allocator.reset();
 			includes.clear();
-			source = scan_includes_recursive(filename, path, includes, ptx_filename.view(), should_recompile);
+			source = scan_includes_recursive(filename, &allocator, path, includes, ptx_filename.view(), should_recompile);
 		}
 
 		// Obtain PTX from NVRTC

--- a/Src/Device/CUDAModule.cpp
+++ b/Src/Device/CUDAModule.cpp
@@ -104,10 +104,12 @@ void CUDAModule::init(const String & module_name, const String & filename, int c
 		IO::exit(1);
 	}
 
+	LinearAllocator<KILOBYTES(512)> allocator;
+
 #ifdef _DEBUG
-	String ptx_filename = Util::combine_stringviews(filename.view(), ".debug.ptx"_sv);
+	String ptx_filename = Util::combine_stringviews(filename.view(), ".debug.ptx"_sv, &allocator);
 #else
-	String ptx_filename = Util::combine_stringviews(filename.view(), ".release.ptx"_sv);
+	String ptx_filename = Util::combine_stringviews(filename.view(), ".release.ptx"_sv, &allocator);
 #endif
 
 	bool should_recompile = true;
@@ -119,8 +121,6 @@ void CUDAModule::init(const String & module_name, const String & filename, int c
 	}
 
 	StringView path = Util::get_directory(filename.view());
-
-	LinearAllocator<KILOBYTES(512)> allocator;
 
 	Array<Include> includes;
 	String source = scan_includes_recursive(filename, &allocator, path, includes, ptx_filename.view(), should_recompile);

--- a/Src/Main.cpp
+++ b/Src/Main.cpp
@@ -106,6 +106,8 @@ int main(int num_args, char ** args) {
 	window.set_size(cpu_config.initial_width, cpu_config.initial_height);
 	window.show();
 
+	LinearAllocator<MEGABYTES(16)> frame_allocator;
+
 	// Render loop
 	while (!window.is_closed) {
 		perf_test.frame_begin();
@@ -124,7 +126,7 @@ int main(int num_args, char ** args) {
 			}
 		}
 
-		integrator->update((float)timing.delta_time);
+		integrator->update((float)timing.delta_time, &frame_allocator);
 		integrator->render();
 
 		window.render_framebuffer();
@@ -176,6 +178,8 @@ int main(int num_args, char ** args) {
 		Input::update(); // Save Keyboard State of this frame before SDL_PumpEvents
 
 		window.swap();
+
+		frame_allocator.reset();
 	}
 
 	CUDAContext::free();

--- a/Src/Main.cpp
+++ b/Src/Main.cpp
@@ -11,6 +11,7 @@
 #include "Core/Sort.h"
 #include "Core/Parser.h"
 #include "Core/Timer.h"
+#include "Core/Allocators/StackAllocator.h"
 
 #include "Input.h"
 #include "Window.h"
@@ -59,8 +60,10 @@ static void calc_timing();
 static void draw_gui(Window & window, Integrator & integrator);
 
 int main(int num_args, char ** args) {
-	Args::parse(num_args, args);
-
+	{
+		StackAllocator<KILOBYTES(4)> allocator;
+		Args::parse(num_args, args, &allocator);
+	}
 	if (cpu_config.scene_filenames.size() == 0) {
 		cpu_config.scene_filenames.push_back("Data/sponza/scene.xml"_sv);
 	}
@@ -138,7 +141,8 @@ int main(int num_args, char ** args) {
 				default: ASSERT_UNREACHABLE();
 			}
 
-			String screenshot_name = Format().format("screenshot_{}.{}"_sv, integrator->sample_index, ext);
+			StackAllocator<BYTES(128)> allocator;
+			String screenshot_name = Format(&allocator).format("screenshot_{}.{}"_sv, integrator->sample_index, ext);
 			capture_screen(window, *integrator.get(), screenshot_name);
 
 			timing.time_of_last_screenshot = timing.now;

--- a/Src/Math/Mipmap.cpp
+++ b/Src/Math/Mipmap.cpp
@@ -5,6 +5,8 @@
 
 #include "Config.h"
 
+#include "Core/Allocators/StackAllocator.h"
+
 template<typename Filter>
 static float filter_sample_box(float x, float scale) {
 	constexpr int   SAMPLE_COUNT     = 32;
@@ -38,12 +40,11 @@ void downsample_impl(int width_src, int height_src, int width_dst, int height_ds
 	int window_size_x = int(ceilf(filter_width_x * 2.0f)) + 1;
 	int window_size_y = int(ceilf(filter_width_y * 2.0f)) + 1;
 
-	Array<float> kernels(window_size_x + window_size_y);
-	float * kernel_x = kernels.data();
-	float * kernel_y = kernels.data() + window_size_x;
-
-	memset(kernel_x, 0, window_size_x * sizeof(float));
-	memset(kernel_y, 0, window_size_y * sizeof(float));
+	StackAllocator<KILOBYTES(16)> allocator;
+	Array<float> kernel_x(window_size_x, &allocator);
+	Array<float> kernel_y(window_size_y, &allocator);
+	memset(kernel_x.data(), 0, window_size_x * sizeof(float));
+	memset(kernel_y.data(), 0, window_size_y * sizeof(float));
 
 	float sum_x = 0.0f;
 	float sum_y = 0.0f;

--- a/Src/Renderer/Integrators/AO.cpp
+++ b/Src/Renderer/Integrators/AO.cpp
@@ -149,12 +149,12 @@ void AO::resize_free() {
 	CUDAMemory::free_surface(surf_accumulator);
 }
 
-void AO::update(float delta) {
+void AO::update(float delta, Allocator * frame_allocator) {
 	if (invalidated_scene) {
 		sample_index = 0;
 	}
 
-	Integrator::update(delta);
+	Integrator::update(delta, frame_allocator);
 }
 
 void AO::render() {

--- a/Src/Renderer/Integrators/AO.h
+++ b/Src/Renderer/Integrators/AO.h
@@ -106,8 +106,8 @@ struct AO final : Integrator {
 	void resize_init(unsigned frame_buffer_handle, int width, int height) override; // Part of resize that initializes new size
 	void resize_free()                                                    override; // Part of resize that cleans up old size
 
-	void update(float delta) override;
-	void render()            override;
+	void update(float delta, Allocator * frame_allocator) override;
+	void render()                                         override;
 
 	void render_gui() override;
 };

--- a/Src/Renderer/Integrators/Integrator.cpp
+++ b/Src/Renderer/Integrators/Integrator.cpp
@@ -7,6 +7,8 @@
 #include "BVH/Converters/BVH4Converter.h"
 #include "BVH/Converters/BVH8Converter.h"
 
+#include "Core/Allocators/PinnedAllocator.h"
+
 #include "Util/BlueNoise.h"
 
 void Integrator::init_globals() {
@@ -203,7 +205,7 @@ void Integrator::init_geometry() {
 			ptr_bvh_nodes_2 = CUDAMemory::malloc<BVHNode2>(aggregated_bvh_nodes);
 			cuda_module.get_global("bvh_nodes").set_value(ptr_bvh_nodes_2);
 
-			tlas           = make_owned<BVH2>();
+			tlas           = make_owned<BVH2>(PinnedAllocator::instance());
 			tlas_converter = make_owned<BVH2Converter>(static_cast<BVH2 &>(*tlas.get()), tlas_raw);
 			break;
 		}
@@ -239,7 +241,7 @@ void Integrator::init_geometry() {
 			ptr_bvh_nodes_4 = CUDAMemory::malloc<BVHNode4>(aggregated_bvh_nodes);
 			cuda_module.get_global("bvh4_nodes").set_value(ptr_bvh_nodes_4);
 
-			tlas           = make_owned<BVH4>();
+			tlas           = make_owned<BVH4>(PinnedAllocator::instance());
 			tlas_converter = make_owned<BVH4Converter>(static_cast<BVH4 &>(*tlas.get()), tlas_raw);
 			break;
 		}
@@ -269,7 +271,7 @@ void Integrator::init_geometry() {
 			ptr_bvh_nodes_8 = CUDAMemory::malloc<BVHNode8>(aggregated_bvh_nodes);
 			cuda_module.get_global("bvh8_nodes").set_value(ptr_bvh_nodes_8);
 
-			tlas           = make_owned<BVH8>();
+			tlas           = make_owned<BVH8>(PinnedAllocator::instance());
 			tlas_converter = make_owned<BVH8Converter>(static_cast<BVH8 &>(*tlas.get()), tlas_raw);
 			break;
 		}

--- a/Src/Renderer/Integrators/Integrator.cpp
+++ b/Src/Renderer/Integrators/Integrator.cpp
@@ -419,7 +419,7 @@ void Integrator::build_tlas() {
 	CUDAMemory::memcpy_async(ptr_mesh_transforms_prev,   pinned_mesh_transforms_prev,  scene.meshes.size(), memory_stream);
 }
 
-void Integrator::update(float delta) {
+void Integrator::update(float delta, Allocator * frame_allocator) {
 	if (invalidated_gpu_config && gpu_config.enable_svgf && scene.camera.aperture_radius > 0.0f) {
 		IO::print("WARNING: SVGF and DoF cannot simultaneously be enabled!\n"_sv);
 		scene.camera.aperture_radius = 0.0f;

--- a/Src/Renderer/Integrators/Integrator.h
+++ b/Src/Renderer/Integrators/Integrator.h
@@ -233,7 +233,7 @@ struct Integrator {
 
 	void build_tlas();
 
-	virtual void update(float delta);
+	virtual void update(float delta, Allocator * frame_allocator);
 	virtual void render() = 0;
 
 	virtual void render_gui() = 0;

--- a/Src/Renderer/Integrators/Pathtracer.cpp
+++ b/Src/Renderer/Integrators/Pathtracer.cpp
@@ -307,7 +307,7 @@ void Pathtracer::svgf_free() {
 }
 
 void Pathtracer::calc_light_power() {
-	LinearAllocator<> allocator;
+	LinearAllocator<MEGABYTES(64)> allocator;
 	HashMap<int, Array<Mesh *>> mesh_data_used_as_lights(&allocator);
 
 	int light_mesh_count = 0;

--- a/Src/Renderer/Integrators/Pathtracer.h
+++ b/Src/Renderer/Integrators/Pathtracer.h
@@ -236,11 +236,11 @@ struct Pathtracer final : Integrator {
 	void svgf_init();
 	void svgf_free();
 
-	void update(float delta) override;
-	void render()            override;
+	void update(float delta, Allocator * frame_allocator) override;
+	void render()                                         override;
 
 	void render_gui() override;
 
-	void calc_light_power();
+	void calc_light_power(Allocator * frame_allocator);
 	void calc_light_mesh_weights();
 };

--- a/Src/Renderer/Scene.cpp
+++ b/Src/Renderer/Scene.cpp
@@ -15,6 +15,8 @@
 #include "Util/StringUtil.h"
 
 Scene::Scene() : camera(Math::deg_to_rad(85.0f)) {
+	LinearAllocator<GIGABYTES(1)> allocator;
+
 	for (int i = 0; i < cpu_config.scene_filenames.size(); i++) {
 		const String & scene_filename = cpu_config.scene_filenames[i];
 
@@ -25,11 +27,11 @@ Scene::Scene() : camera(Math::deg_to_rad(85.0f)) {
 		}
 
 		if (file_extension == "obj") {
-			add_mesh(scene_filename, asset_manager.add_mesh_data(scene_filename, OBJLoader::load));
+			add_mesh(scene_filename, asset_manager.add_mesh_data(scene_filename, &allocator, OBJLoader::load));
 		} else if (file_extension == "ply") {
-			add_mesh(scene_filename, asset_manager.add_mesh_data(scene_filename, PLYLoader::load));
+			add_mesh(scene_filename, asset_manager.add_mesh_data(scene_filename, &allocator, PLYLoader::load));
 		} else if (file_extension == "xml") {
-			MitsubaLoader::load(scene_filename, *this);
+			MitsubaLoader::load(scene_filename, &allocator, *this);
 		} else {
 			IO::print("ERROR: '{}' file format is not supported!\n"_sv, file_extension);
 			IO::exit(1);

--- a/Src/Renderer/Scene.cpp
+++ b/Src/Renderer/Scene.cpp
@@ -15,7 +15,7 @@
 #include "Util/StringUtil.h"
 
 Scene::Scene() : camera(Math::deg_to_rad(85.0f)) {
-	LinearAllocator<GIGABYTES(1)> allocator;
+	LinearAllocator<MEGABYTES(4)> allocator;
 
 	for (int i = 0; i < cpu_config.scene_filenames.size(); i++) {
 		const String & scene_filename = cpu_config.scene_filenames[i];

--- a/Src/Util/StringUtil.cpp
+++ b/Src/Util/StringUtil.cpp
@@ -36,8 +36,8 @@ StringView Util::substr(StringView str, size_t offset, size_t len) {
 	return { str.start + offset, str.start + offset + len };
 }
 
-String Util::combine_stringviews(StringView a, StringView b) {
-	String filename_abs = String(a.length() + b.length());
+String Util::combine_stringviews(StringView a, StringView b, Allocator * allocator) {
+	String filename_abs = String(a.length() + b.length(), allocator);
 
 	memcpy(filename_abs.data(),              a.start, a.length());
 	memcpy(filename_abs.data() + a.length(), b.start, b.length());

--- a/Src/Util/StringUtil.cpp
+++ b/Src/Util/StringUtil.cpp
@@ -133,28 +133,28 @@ static int uint64_to_string(uint64_t value, uint64_t base, char * buf) {
 	return offset;
 }
 
-String Util::to_string(bool value) {
-	return value ? "true"_sv : "false"_sv;
+String Util::to_string(bool value, Allocator * allocator) {
+	return String(value ? "true"_sv : "false"_sv, allocator);
 }
 
-String Util::to_string(int64_t value, int64_t base) {
+String Util::to_string(int64_t value, int64_t base, Allocator * allocator) {
 	char buf[64] = { };
 	int length = int64_to_string(value, base, buf);
-	return String(buf, length);
+	return String(buf, length, allocator);
 }
 
-String Util::to_string(uint64_t value, uint64_t base) {
+String Util::to_string(uint64_t value, uint64_t base, Allocator * allocator) {
 	char buf[64] = { };
 	int length = uint64_to_string(value, base, buf);
-	return String(buf, length);
+	return String(buf, length, allocator);
 }
 
-String Util::to_string(double value) {
+String Util::to_string(double value, Allocator * allocator) {
 	if (isinf(value)) {
-		return value > 0.0f ? "inf"_sv : "-inf"_sv;
+		return String(value > 0.0f ? "inf"_sv : "-inf"_sv, allocator);
 	}
 	if (isnan(value)) {
-		return "nan"_sv;
+		return String("nan"_sv, allocator);
 	}
 
 	// Based on: https://github.com/antongus/stm32tpl/blob/master/ftoa.c
@@ -192,5 +192,5 @@ String Util::to_string(double value) {
 		value = value - floor(value);
 	}
 
-	return String(buf, offset);
+	return String(buf, offset, allocator);
 }

--- a/Src/Util/StringUtil.h
+++ b/Src/Util/StringUtil.h
@@ -3,6 +3,7 @@
 
 #include "Core/String.h"
 #include "Core/StringView.h"
+#include "Core/Allocators/LinearAllocator.h"
 
 namespace Util {
 	StringView get_directory(StringView filename);
@@ -12,7 +13,7 @@ namespace Util {
 
 	StringView substr(StringView str, size_t offset, size_t len = -1);
 
-	String combine_stringviews(StringView path, StringView filename);
+	String combine_stringviews(StringView path, StringView filename, Allocator * allocator = nullptr);
 
 	const char * find_last_after(StringView haystack, StringView needles);
 

--- a/Src/Util/StringUtil.h
+++ b/Src/Util/StringUtil.h
@@ -19,8 +19,8 @@ namespace Util {
 
 	const char * strstr(StringView haystack, StringView needle);
 
-	String to_string(bool     value);
-	String to_string(int64_t  value, int64_t  base = 10);
-	String to_string(uint64_t value, uint64_t base = 10);
-	String to_string(double   value);
+	String to_string(bool     value,                     Allocator * allocator = nullptr);
+	String to_string(int64_t  value, int64_t  base = 10, Allocator * allocator = nullptr);
+	String to_string(uint64_t value, uint64_t base = 10, Allocator * allocator = nullptr);
+	String to_string(double   value,                     Allocator * allocator = nullptr);
 }

--- a/Src/Util/Util.h
+++ b/Src/Util/Util.h
@@ -3,6 +3,20 @@
 
 #define FORCEINLINE __forceinline
 
+#define NON_COPYABLE(Name)       \
+	Name(const Name &) = delete; \
+	Name & operator=(const Name &) = delete;
+#define NON_MOVEABLE(Name)  \
+	Name(Name &&) = delete; \
+	Name & operator=(Name &&) = delete;
+
+#define DEFAULT_COPYABLE(Name)    \
+	Name(const Name &) = default; \
+	Name & operator=(const Name &) = default;
+#define DEFAULT_MOVEABLE(Name) \
+	Name(Name &&) = default;   \
+	Name & operator=(Name &&) = default;
+
 namespace Util {
 	template<typename T>
 	constexpr void swap(T & a, T & b) {

--- a/Src/Util/Util.h
+++ b/Src/Util/Util.h
@@ -3,20 +3,6 @@
 
 #define FORCEINLINE __forceinline
 
-#define NON_COPYABLE(Name)       \
-	Name(const Name &) = delete; \
-	Name & operator=(const Name &) = delete;
-#define NON_MOVEABLE(Name)  \
-	Name(Name &&) = delete; \
-	Name & operator=(Name &&) = delete;
-
-#define DEFAULT_COPYABLE(Name)    \
-	Name(const Name &) = default; \
-	Name & operator=(const Name &) = default;
-#define DEFAULT_MOVEABLE(Name) \
-	Name(Name &&) = default;   \
-	Name & operator=(Name &&) = default;
-
 namespace Util {
 	template<typename T>
 	constexpr void swap(T & a, T & b) {

--- a/Src/Window.cpp
+++ b/Src/Window.cpp
@@ -68,7 +68,7 @@ Window::Window(const String & title, int width, int height) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
 
-	StackAllocator<> allocator;
+	StackAllocator<KILOBYTES(4)> allocator;
 	String shader_source_vertex   = IO::file_read("Src/Shaders/post.vert", &allocator);
 	String shader_source_fragment = IO::file_read("Src/Shaders/post.frag", &allocator);
 

--- a/Src/Window.cpp
+++ b/Src/Window.cpp
@@ -7,6 +7,7 @@
 #include <Imgui/imgui_impl_opengl3.h>
 
 #include "Core/IO.h"
+#include "Core/Allocators/StackAllocator.h"
 
 #include "Math/Math.h"
 #include "Util/Util.h"
@@ -67,10 +68,11 @@ Window::Window(const String & title, int width, int height) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
 
-	String shader_vertex   = IO::file_read("Src/Shaders/post.vert");
-	String shader_fragment = IO::file_read("Src/Shaders/post.frag");
+	StackAllocator<> allocator;
+	String shader_source_vertex   = IO::file_read("Src/Shaders/post.vert", &allocator);
+	String shader_source_fragment = IO::file_read("Src/Shaders/post.frag", &allocator);
 
-	shader = Shader::load(shader_vertex.view(), shader_fragment.view());
+	shader = Shader::load(shader_source_vertex.view(), shader_source_fragment.view());
 	shader.bind();
 
 	glUniform1i(shader.get_uniform("screen"), 0);


### PR DESCRIPTION
Abstraction for different memory allocation strategies.
This allows e.g. the TLAS `Array<BVHNode>` to use CUDA pinned memory to avoid an additional copy when uploading to the GPU.

Implemented Allocators:
 - `LinearAllocator`
 - `PinnedAllocator`
 - `StackAllocator`